### PR TITLE
Fix logging strings in auth middleware

### DIFF
--- a/backend/src/api/routes.py
+++ b/backend/src/api/routes.py
@@ -75,13 +75,13 @@ async def auth_middleware(request: Request, call_next):
                 current_entity = verify_user_token(token, db)
                 request.state.current_entity = current_entity
             except HTTPException as e:
-                logger.info("1",e)
+                logger.info("1 %s", e)
                 return JSONResponse(
                     content={"detail": e.detail},
                     status_code=e.status_code
                 )
             except Exception as e:
-                logger.info("2",e)
+                logger.info("2 %s", e)
                 return JSONResponse(
                     content={"detail": f"Error interno en la verificación del token: {str(e)}"},
                     status_code=500
@@ -95,7 +95,7 @@ async def auth_middleware(request: Request, call_next):
         response = await call_next(request)
         return response
     except Exception as e:
-        logger.info("3",e)
+        logger.info("3 %s", e)
         return JSONResponse(
             content={"detail": "Error interno en el procesamiento de la solicitud"},
             status_code=500


### PR DESCRIPTION
## Summary
- use format strings with logger in `auth_middleware`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68868ca4872483288a06fa4bc2af91f1