### PR TITLE
Add firebase uid migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Sistema de gestión de cuadrillas para obras de mantenimiento.
 4. Backend: cd backend && pip install -r requirements.txt && cd src && uvicorn main:app --host 0.0.0.0 --port 8000
 5. Frontend: cd frontend && npm install && npm run dev
 
+## Migraciones de base de datos
+Para alinear el esquema de la base de datos con los modelos se proporciona un
+script de migración sencillo:
+
+```bash
+cd backend && python -m migrations.002_add_firebase_uid
+```
+
+Ejecuta este comando durante el despliegue para añadir las columnas
+`firebase_uid` en `mensaje_correctivo` y `mensaje_preventivo`.
+
 ## Tests con code coverage
 1. Backend: cd backend && pytest -v --cov=src --cov-report=xml --junitxml=pytest-report.xml
 2. Frontend: cd frontend && npm test -- --coverage --ci

--- a/backend/migrations/002_add_firebase_uid.py
+++ b/backend/migrations/002_add_firebase_uid.py
@@ -1,0 +1,26 @@
+import os
+from sqlalchemy import create_engine, inspect, text
+from dotenv import load_dotenv
+
+# Load environment configuration
+env_path = os.path.join(os.path.dirname(__file__), '..', 'src', 'env.config')
+load_dotenv(env_path)
+DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///./test.db')
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith('sqlite') else {}
+)
+
+def add_column_if_not_exists(connection, table_name, column_def):
+    inspector = inspect(connection)
+    if table_name in inspector.get_table_names():
+        columns = [c['name'] for c in inspector.get_columns(table_name)]
+        col_name = column_def.split()[0]
+        if col_name not in columns:
+            connection.execute(text(f'ALTER TABLE {table_name} ADD COLUMN {column_def}'))
+
+with engine.begin() as connection:
+    add_column_if_not_exists(connection, 'mensaje_correctivo', 'firebase_uid VARCHAR')
+    add_column_if_not_exists(connection, 'mensaje_preventivo', 'firebase_uid VARCHAR')
+

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -146,7 +146,7 @@ class PreventivoSeleccionado(Base):
 class MensajeCorrectivo(Base):
     __tablename__ = "mensaje_correctivo"
     id = Column(Integer, primary_key=True)
-    firebase_uid = Column(String, unique=True)
+    firebase_uid = Column(String)
     nombre_usuario = Column(String)
     id_mantenimiento = Column(Integer, ForeignKey("mantenimiento_correctivo.id"))
     texto = Column(String, nullable=True)
@@ -158,7 +158,7 @@ class MensajeCorrectivo(Base):
 class MensajePreventivo(Base):
     __tablename__ = "mensaje_preventivo"
     id = Column(Integer, primary_key=True)
-    firebase_uid = Column(String, unique=True)
+    firebase_uid = Column(String)
     nombre_usuario = Column(String)
     id_mantenimiento = Column(Integer, ForeignKey("mantenimiento_preventivo.id"))
     texto = Column(String, nullable=True)


### PR DESCRIPTION
## Summary
- add migration script for firebase_uid columns
- update models to make firebase_uid non-unique
- document migration step in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68868ca778a88328a157aab8fa9d8afc