### PR TITLE
Handle empty chat responses

### DIFF
--- a/backend/src/services/chats.py
+++ b/backend/src/services/chats.py
@@ -21,16 +21,12 @@ def get_chat_correctivo(db_session: Session, mantenimiento_id: int, current_enti
     if not current_entity:
         raise HTTPException(status_code=401, detail="Autenticación requerida")
     chat = db_session.query(MensajeCorrectivo).filter(MensajeCorrectivo.id_mantenimiento == mantenimiento_id).all()
-    if not chat:
-        raise HTTPException(status_code=404, detail="No hay mensajes")
     return chat
 
 def get_chat_preventivo(db_session: Session, mantenimiento_id: int, current_entity: dict):
     if not current_entity:
         raise HTTPException(status_code=401, detail="Autenticación requerida")
     chat = db_session.query(MensajePreventivo).filter(MensajePreventivo.id_mantenimiento == mantenimiento_id).all()
-    if not chat:
-        raise HTTPException(status_code=404, detail="No hay mensajes")
     return chat
 
 async def send_message_correctivo(

--- a/backend/tests/test_services/test_chats.py
+++ b/backend/tests/test_services/test_chats.py
@@ -1,0 +1,14 @@
+import pytest
+from src.services import chats as chats_service
+
+
+def test_get_chat_correctivo_empty(db_session):
+    current_entity = {"user": "test"}
+    chat = chats_service.get_chat_correctivo(db_session, 1, current_entity)
+    assert chat == []
+
+
+def test_get_chat_preventivo_empty(db_session):
+    current_entity = {"user": "test"}
+    chat = chats_service.get_chat_preventivo(db_session, 1, current_entity)
+    assert chat == []


### PR DESCRIPTION
## Summary
- allow chat service to return an empty list when no messages
- add tests covering empty chat response behavior

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q tests/test_services/test_chats.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68868ca7025c832881e22c195ffa1f33