### PR TITLE
Add WebSocket chat manager for maintenance groups

### DIFF
--- a/backend/src/api/routes.py
+++ b/backend/src/api/routes.py
@@ -1,9 +1,10 @@
-from fastapi import FastAPI, Request, HTTPException
+from fastapi import FastAPI, Request, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from controllers import users, cuadrillas, sucursales, zonas, auth, preventivos, mantenimientos_preventivos, mantenimientos_correctivos, maps, notificaciones, push, chats
 from config.database import get_db
 from services.auth import verify_user_token
+from services.chat_ws import manager
 from auth.firebase import initialize_firebase
 from init_admin import init_admin
 from dotenv import load_dotenv
@@ -89,6 +90,15 @@ async def auth_middleware(request: Request, call_next):
             content={"detail": "Error interno en el procesamiento de la solicitud"},
             status_code=500
         )
+
+@app.websocket("/ws/chat/{mantenimiento_id}")
+async def websocket_route(websocket: WebSocket, mantenimiento_id: int):
+    await manager.connect(mantenimiento_id, websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(mantenimiento_id, websocket)
 
 app.include_router(users.router)
 app.include_router(cuadrillas.router)

--- a/backend/src/services/chat_ws.py
+++ b/backend/src/services/chat_ws.py
@@ -1,0 +1,33 @@
+from typing import Dict, List
+from fastapi import WebSocket
+
+
+class ChatConnectionManager:
+    """Manage websocket connections per mantenimiento."""
+
+    def __init__(self) -> None:
+        # Map mantenimiento_id to list of active WebSocket connections
+        self.active_connections: Dict[int, List[WebSocket]] = {}
+
+    async def connect(self, mantenimiento_id: int, websocket: WebSocket) -> None:
+        """Accept and store a new websocket connection."""
+        await websocket.accept()
+        self.active_connections.setdefault(mantenimiento_id, []).append(websocket)
+
+    def disconnect(self, mantenimiento_id: int, websocket: WebSocket) -> None:
+        """Remove a websocket connection for the given mantenimiento."""
+        connections = self.active_connections.get(mantenimiento_id, [])
+        if websocket in connections:
+            connections.remove(websocket)
+        if not connections and mantenimiento_id in self.active_connections:
+            del self.active_connections[mantenimiento_id]
+
+    async def send_message(self, mantenimiento_id: int, message: dict) -> None:
+        """Send a message to all connections of a mantenimiento."""
+        connections = self.active_connections.get(mantenimiento_id, [])
+        for connection in connections:
+            await connection.send_json(message)
+
+
+# Shared instance used across the application
+manager = ChatConnectionManager()

--- a/backend/src/services/chats.py
+++ b/backend/src/services/chats.py
@@ -3,6 +3,7 @@ from api.models import MensajeCorrectivo, MensajePreventivo
 from fastapi import HTTPException, UploadFile
 from typing import Optional
 from services.gcloud_storage import upload_chat_file_to_gcloud
+from services.chat_ws import manager
 import os
 
 GOOGLE_CLOUD_BUCKET_NAME = os.getenv("GOOGLE_CLOUD_BUCKET_NAME")
@@ -55,10 +56,23 @@ async def send_message_correctivo(
         db_session.add(db_message)
         db_session.commit()
         db_session.refresh(db_message)
+        await manager.send_message(
+            id_mantenimiento,
+            {
+                "id": db_message.id,
+                "firebase_uid": db_message.firebase_uid,
+                "nombre_usuario": db_message.nombre_usuario,
+                "id_mantenimiento": db_message.id_mantenimiento,
+                "texto": db_message.texto,
+                "archivo": db_message.archivo,
+                "fecha": db_message.created_at.isoformat() if db_message.created_at else None,
+            },
+        )
         return db_message
     except Exception as e:
         db_session.rollback()
         raise HTTPException(status_code=500, detail=f"Error interno: {str(e)}")
+
 
 async def send_message_preventivo(
     db_session: Session,
@@ -92,6 +106,18 @@ async def send_message_preventivo(
         db_session.add(db_message)
         db_session.commit()
         db_session.refresh(db_message)
+        await manager.send_message(
+            id_mantenimiento,
+            {
+                "id": db_message.id,
+                "firebase_uid": db_message.firebase_uid,
+                "nombre_usuario": db_message.nombre_usuario,
+                "id_mantenimiento": db_message.id_mantenimiento,
+                "texto": db_message.texto,
+                "archivo": db_message.archivo,
+                "fecha": db_message.created_at.isoformat() if db_message.created_at else None,
+            },
+        )
         return db_message
     except Exception as e:
         db_session.rollback()


### PR DESCRIPTION
## Summary
- manage WebSocket chat connections per maintenance group
- expose `/ws/chat/{mantenimiento_id}` endpoint using the connection manager
- broadcast persisted chat messages to connected clients

## Testing
- `GOOGLE_CREDENTIALS='{}' GOOGLE_CLOUD_BUCKET_NAME='test' TESTING=true pytest` *(fails: TypeError in service tests and 14 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6896b5e3e8b88328b0bdbbcbebe9713f