### PR TITLE
Mock Firebase in sucursal service tests

### DIFF
--- a/backend/tests/test_services/test_sucursales.py
+++ b/backend/tests/test_services/test_sucursales.py
@@ -1,13 +1,27 @@
+import os
 import pytest
+from unittest.mock import MagicMock, patch
+
+os.environ["TESTING"] = "true"
+
 from src.services import sucursales as sucursales_service
+
+
+@pytest.fixture(autouse=True)
+def mock_firebase():
+    with patch("auth.firebase.initialize_firebase"), \
+         patch("src.services.sucursales.initialize_firebase"), \
+         patch("firebase_admin.db.reference", return_value=MagicMock()):
+        yield
 
 def test_create_sucursal(db_session):
     sucursal = sucursales_service.create_sucursal(
-        db=db_session,
+        db_session=db_session,
         nombre="Sucursal Test",
         zona="Zona Norte",
-        direccion="Av. Test 123",
-        superficie="100m2"
+        direccion={"address": "Av. Test 123", "lat": 0, "lng": 0},
+        superficie="100m2",
+        current_entity={"type": "usuario"},
     )
     assert sucursal.id is not None
     assert sucursal.nombre == "Sucursal Test"
@@ -17,33 +31,69 @@ def test_create_sucursal(db_session):
 
 def test_get_sucursales(db_session):
     # Crear dos sucursales
-    sucursales_service.create_sucursal(db_session, "Sucursal 1", "Zona 1", "Dirección 1", "50m2")
-    sucursales_service.create_sucursal(db_session, "Sucursal 2", "Zona 2", "Dirección 2", "70m2")
+    sucursales_service.create_sucursal(
+        db_session,
+        "Sucursal 1",
+        "Zona 1",
+        {"address": "Dirección 1", "lat": 0, "lng": 0},
+        "50m2",
+        {"type": "usuario"},
+    )
+    sucursales_service.create_sucursal(
+        db_session,
+        "Sucursal 2",
+        "Zona 2",
+        {"address": "Dirección 2", "lat": 0, "lng": 0},
+        "70m2",
+        {"type": "usuario"},
+    )
 
     sucursales = sucursales_service.get_sucursales(db_session)
     assert len(sucursales) == 2
 
 def test_get_sucursal(db_session):
-    nueva_sucursal = sucursales_service.create_sucursal(db_session, "Sucursal Única", "Zona Única", "Dirección Única", "150m2")
+    nueva_sucursal = sucursales_service.create_sucursal(
+        db_session,
+        "Sucursal Única",
+        "Zona Única",
+        {"address": "Dirección Única", "lat": 0, "lng": 0},
+        "150m2",
+        {"type": "usuario"},
+    )
     sucursal = sucursales_service.get_sucursal(db_session, nueva_sucursal.id)
     assert sucursal.nombre == "Sucursal Única"
 
 def test_update_sucursal(db_session):
-    nueva_sucursal = sucursales_service.create_sucursal(db_session, "Sucursal vieja", "Zona vieja", "Dirección vieja", "90m2")
+    nueva_sucursal = sucursales_service.create_sucursal(
+        db_session,
+        "Sucursal vieja",
+        "Zona vieja",
+        {"address": "Dirección vieja", "lat": 0, "lng": 0},
+        "90m2",
+        {"type": "usuario"},
+    )
     actualizada = sucursales_service.update_sucursal(
-        db_session, 
-        nueva_sucursal.id, 
+        db_session,
+        nueva_sucursal.id,
+        {"type": "usuario"},
         nombre="Sucursal actualizada",
         zona="Zona actualizada",
-        direccion="Dirección actualizada",
+        direccion={"address": "Dirección actualizada", "lat": 0, "lng": 0},
         superficie="95m2"
     )
     assert actualizada.nombre == "Sucursal actualizada"
     assert actualizada.zona == "Zona actualizada"
 
 def test_delete_sucursal(db_session):
-    nueva_sucursal = sucursales_service.create_sucursal(db_session, "Sucursal para borrar", "Zona X", "Dirección X", "60m2")
-    response = sucursales_service.delete_sucursal(db_session, nueva_sucursal.id)
+    nueva_sucursal = sucursales_service.create_sucursal(
+        db_session,
+        "Sucursal para borrar",
+        "Zona X",
+        {"address": "Dirección X", "lat": 0, "lng": 0},
+        "60m2",
+        {"type": "usuario"},
+    )
+    response = sucursales_service.delete_sucursal(db_session, nueva_sucursal.id, {"type": "usuario"})
     assert response["message"] == f"Sucursal con id {nueva_sucursal.id} eliminada"
 
     # Verificar que no existe más


### PR DESCRIPTION
## Summary
- ensure sucursal tests pass current user and address dict to service calls
- mock Firebase initialization and database reference in tests

## Testing
- `TESTING=true GOOGLE_CREDENTIALS='{}' pytest backend/tests/test_services/test_sucursales.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba20ce06083289a0e902cf66f2abc