### PR TITLE
Evita inicializar Firebase durante tests

### DIFF
--- a/backend/src/api/routes.py
+++ b/backend/src/api/routes.py
@@ -24,8 +24,9 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-initialize_firebase()
-init_admin(email=EMAIL_ADMIN, nombre=NOMBRE_ADMIN, password=PASSWORD_ADMIN)
+if os.environ.get("TESTING") != "true":
+    initialize_firebase()
+    init_admin(email=EMAIL_ADMIN, nombre=NOMBRE_ADMIN, password=PASSWORD_ADMIN)
 
 # Configuración de CORS
 origins = [

--- a/backend/src/services/maps.py
+++ b/backend/src/services/maps.py
@@ -1,10 +1,11 @@
-from fastapi import HTTPException   
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 from api.models import CorrectivoSeleccionado, PreventivoSeleccionado, Cuadrilla, Usuario
 from pydantic import BaseModel
 from typing import List
 from firebase_admin import db
 from auth.firebase import initialize_firebase
+import os
 
 class Sucursal(BaseModel):
     id: str
@@ -22,7 +23,10 @@ class Usuarios(BaseModel):
 async def get_sucursales_locations(current_entity: dict) -> List[Sucursal]:
     if not current_entity:
         raise HTTPException(status_code=401, detail="Autenticación requerida")
-    
+
+    if os.environ.get("TESTING") == "true":
+        return []
+
     try:
         initialize_firebase()
         ref = db.reference('/sucursales')
@@ -46,7 +50,10 @@ async def get_users_locations(current_entity: dict) -> List[Usuarios]:
         raise HTTPException(status_code=401, detail="Autenticación requerida")
     if current_entity["type"] != "usuario":
         raise HTTPException(status_code=403, detail="No tienes permisos")
-    
+
+    if os.environ.get("TESTING") == "true":
+        return []
+
     try:
         initialize_firebase()
         ref = db.reference('/users')
@@ -89,7 +96,10 @@ def get_preventivos(db_session: Session, id_cuadrilla: int, current_entity: dict
 async def update_user_location(current_entity: dict, firebase_uid: str, user_id: str, tipo: str, name: str, lat: float, lng: float):
     if not current_entity:
         raise HTTPException(status_code=401, detail="Autenticación requerida")
-    
+
+    if os.environ.get("TESTING") == "true":
+        return {"message": f"Ubicación actualizada para {user_id}"}
+
     try:
         initialize_firebase()
         ref = db.reference(f'/users/{firebase_uid}')


### PR DESCRIPTION
## Summary
- Condiciona la inicialización de Firebase y la creación del admin para ejecutarse solo fuera de modo `TESTING`.
- Omite las operaciones en Firebase de los servicios de sucursales y mapas cuando se ejecutan pruebas.

## Testing
- ❌ `GOOGLE_CREDENTIALS='{}' TESTING=true pytest` (14 tests failed)


------
https://chatgpt.com/codex/tasks/task_e_689ba20f3d08832892f40c37160a8824