### PR TITLE
refactor: use test client fixture

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,8 @@
 import os
+
+os.environ["TESTING"] = "true"
+os.environ.setdefault("GOOGLE_CREDENTIALS", "{}")
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -6,6 +10,24 @@ from sqlalchemy.orm import sessionmaker
 from src.api.routes import app
 from src.api.models import Base
 from src.config.database import get_db
+from unittest.mock import MagicMock
+import services.sucursales as sucursales_service
+
+
+class _DummyRef:
+    def set(self, *args, **kwargs):
+        pass
+
+    def update(self, *args, **kwargs):
+        pass
+
+    def delete(self, *args, **kwargs):
+        pass
+
+
+_db_mock = MagicMock()
+_db_mock.reference.return_value = _DummyRef()
+sucursales_service.db = _db_mock
 
 # Configuramos la base de datos de testing
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"

--- a/backend/tests/test_controllers/test_sucursales.py
+++ b/backend/tests/test_controllers/test_sucursales.py
@@ -1,24 +1,16 @@
+import os
+
+os.environ["TESTING"] = "true"
+
 import pytest
-from fastapi.testclient import TestClient
-from src.api.routes import app
-from src.config.database import SessionLocal
 
-client = TestClient(app)
 
-def override_get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-app.dependency_overrides = {}
-
-def test_create_sucursal():
+def test_create_sucursal(client):
+    client.post("/zonas/", json={"nombre": "Zona Controller"})
     response = client.post("/sucursales/", json={
         "nombre": "Sucursal Controller",
         "zona": "Zona Controller",
-        "direccion": "Dirección Controller",
+        "direccion": {"address": "Dirección Controller", "lat": 0.0, "lng": 0.0},
         "superficie": "80m2"
     })
     assert response.status_code == 200
@@ -26,17 +18,18 @@ def test_create_sucursal():
     assert data["nombre"] == "Sucursal Controller"
     assert "id" in data
 
-def test_listar_sucursales():
+def test_listar_sucursales(client):
     response = client.get("/sucursales/")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
-def test_get_sucursal():
+def test_get_sucursal(client):
     # Primero creamos
+    client.post("/zonas/", json={"nombre": "Zona GET"})
     post_response = client.post("/sucursales/", json={
         "nombre": "Sucursal para GET",
         "zona": "Zona GET",
-        "direccion": "Dirección GET",
+        "direccion": {"address": "Dirección GET", "lat": 0.0, "lng": 0.0},
         "superficie": "85m2"
     })
     sucursal_id = post_response.json()["id"]
@@ -46,12 +39,14 @@ def test_get_sucursal():
     assert get_response.status_code == 200
     assert get_response.json()["id"] == sucursal_id
 
-def test_update_sucursal():
+def test_update_sucursal(client):
     # Crear
+    client.post("/zonas/", json={"nombre": "Zona"})
+    client.post("/zonas/", json={"nombre": "Zona Actualizada"})
     post_response = client.post("/sucursales/", json={
         "nombre": "Sucursal para UPDATE",
         "zona": "Zona",
-        "direccion": "Dirección",
+        "direccion": {"address": "Dirección", "lat": 0.0, "lng": 0.0},
         "superficie": "90m2"
     })
     sucursal_id = post_response.json()["id"]
@@ -60,18 +55,19 @@ def test_update_sucursal():
     put_response = client.put(f"/sucursales/{sucursal_id}", json={
         "nombre": "Sucursal Actualizada",
         "zona": "Zona Actualizada",
-        "direccion": "Dirección Actualizada",
+        "direccion": {"address": "Dirección Actualizada", "lat": 1.0, "lng": 1.0},
         "superficie": "95m2"
     })
     assert put_response.status_code == 200
     assert put_response.json()["nombre"] == "Sucursal Actualizada"
 
-def test_delete_sucursal():
+def test_delete_sucursal(client):
     # Crear
+    client.post("/zonas/", json={"nombre": "Zona"})
     post_response = client.post("/sucursales/", json={
         "nombre": "Sucursal para DELETE",
         "zona": "Zona",
-        "direccion": "Dirección",
+        "direccion": {"address": "Dirección", "lat": 0.0, "lng": 0.0},
         "superficie": "100m2"
     })
     sucursal_id = post_response.json()["id"]


### PR DESCRIPTION
## Summary
- use pytest client fixture in controller tests
- set TESTING env var and mock firebase in tests

## Testing
- `pytest backend/tests/test_controllers/test_sucursales.py backend/tests/test_controllers/test_zonas.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689ba212f15c8328bfa1d445270cb16a