### PR TITLE
test: configure testing environment for route tests

### DIFF
--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,8 +1,9 @@
+import os
 import pytest
-from fastapi.testclient import TestClient
-from src.api.routes import app
 
-client = TestClient(app)
+os.environ["TESTING"] = "true"
+
+from src.api.routes import app
 
 def test_app_instance():
     """ Verifica que la instancia de app es de FastAPI """


### PR DESCRIPTION
## Summary
- set TESTING env var before importing app in route tests to skip firebase

## Testing
- `GOOGLE_CREDENTIALS='{}' TESTING=true pytest -q` *(fails: create_sucursal, get_sucursal, update_sucursal, delete_sucursal, create_sucursal, get_sucursales, get_sucursal, update_sucursal, delete_sucursal, create_zona, create_zona_already_exists, get_zonas, delete_zona, delete_zona_in_use)*

------
https://chatgpt.com/codex/tasks/task_e_689ba2157ad48328b1a417933f14028d