### PR TITLE
Adjust sucursales and zonas tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,66 +1,58 @@
 import os
-
-# Configurar variables de entorno **antes** de importar la aplicación
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-os.environ["TESTING"] = "true"
-os.environ.setdefault("GOOGLE_CREDENTIALS", "{}")
+import sys
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import sessionmaker
+
+# Configurar variables de entorno antes de importar la aplicación
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["TESTING"] = "true"
+os.environ.setdefault("GOOGLE_CREDENTIALS", "{}")
+
+# Asegurar que los paquetes del backend sean importables
+BASE_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE_DIR))
+sys.path.append(str(BASE_DIR / "src"))
+
 from src.api.routes import app
 from src.api.models import Base
-from src.config.database import (
-    SessionLocal as AppSessionLocal,
-    engine as app_engine,
-    get_db,
-)
+from src.config.database import SessionLocal as AppSessionLocal, engine as app_engine, get_db
 
-# Verificar que la aplicación usa la base de datos en memoria
-assert str(app_engine.url) == "sqlite:///:memory:"
-assert str(AppSessionLocal.kw["bind"].url) == "sqlite:///:memory:"
-
-# Usar el mismo engine de la aplicación para las pruebas
 engine = app_engine
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-# --- Fixtures ---
 
 @pytest.fixture(scope="session", autouse=True)
 def prepare_database():
-    """Crea y destruye las tablas de la base de datos para toda la sesión de tests"""
-    # Verificar que DATABASE_URL es in-memory
-    assert os.environ["DATABASE_URL"] == "sqlite:///:memory:", "DATABASE_URL no está configurado como in-memory"
-    
     Base.metadata.create_all(bind=engine)
     yield
     Base.metadata.drop_all(bind=engine)
+    if os.path.exists("test.db"):
+        os.remove("test.db")
+
 
 @pytest.fixture(scope="function")
 def db_session():
-    """Crea una sesión de base de datos nueva para cada test"""
-    connection = engine.connect()
-    transaction = connection.begin()
-    session = TestingSessionLocal(bind=connection)
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
 
-    yield session
 
-    session.close()
-    transaction.rollback()
-    connection.close()
-
-@pytest.fixture(scope="module")
-def client():
-    """Cliente de test que usa la base de datos de testing"""
-
-    # Dependency override para que FastAPI use la DB de testing
+@pytest.fixture(scope="function")
+def client(db_session):
     def override_get_db():
-        db = TestingSessionLocal()
         try:
-            yield db
+            yield db_session
         finally:
-            db.close()
+            pass
 
     app.dependency_overrides[get_db] = override_get_db
 
     return TestClient(app)
+

--- a/backend/tests/test_controllers/test_sucursales.py
+++ b/backend/tests/test_controllers/test_sucursales.py
@@ -1,82 +1,103 @@
 import pytest
-from fastapi.testclient import TestClient
-from src.api.routes import app
-from src.config.database import SessionLocal
 
-client = TestClient(app)
 
-def override_get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-app.dependency_overrides = {}
-
-def test_create_sucursal():
-    response = client.post("/sucursales/", json={
-        "nombre": "Sucursal Controller",
-        "zona": "Zona Controller",
-        "direccion": "Dirección Controller",
-        "superficie": "80m2"
-    })
+def test_create_sucursal(client):
+    response = client.post(
+        "/sucursales/",
+        json={
+            "nombre": "Sucursal Controller",
+            "zona": "Zona Controller",
+            "direccion": {
+                "address": "Dirección Controller",
+                "lat": 0.0,
+                "lng": 0.0,
+            },
+            "superficie": "80m2",
+        },
+    )
     assert response.status_code == 200
     data = response.json()
     assert data["nombre"] == "Sucursal Controller"
     assert "id" in data
 
-def test_listar_sucursales():
+
+def test_listar_sucursales(client):
     response = client.get("/sucursales/")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
-def test_get_sucursal():
-    # Primero creamos
-    post_response = client.post("/sucursales/", json={
-        "nombre": "Sucursal para GET",
-        "zona": "Zona GET",
-        "direccion": "Dirección GET",
-        "superficie": "85m2"
-    })
+
+def test_get_sucursal(client):
+    post_response = client.post(
+        "/sucursales/",
+        json={
+            "nombre": "Sucursal para GET",
+            "zona": "Zona GET",
+            "direccion": {
+                "address": "Dirección GET",
+                "lat": 0.0,
+                "lng": 0.0,
+            },
+            "superficie": "85m2",
+        },
+    )
     sucursal_id = post_response.json()["id"]
 
-    # Luego la pedimos
     get_response = client.get(f"/sucursales/{sucursal_id}")
     assert get_response.status_code == 200
     assert get_response.json()["id"] == sucursal_id
 
-def test_update_sucursal():
-    # Crear
-    post_response = client.post("/sucursales/", json={
-        "nombre": "Sucursal para UPDATE",
-        "zona": "Zona",
-        "direccion": "Dirección",
-        "superficie": "90m2"
-    })
+
+def test_update_sucursal(client):
+    post_response = client.post(
+        "/sucursales/",
+        json={
+            "nombre": "Sucursal para UPDATE",
+            "zona": "Zona",
+            "direccion": {
+                "address": "Dirección",
+                "lat": 0.0,
+                "lng": 0.0,
+            },
+            "superficie": "90m2",
+        },
+    )
     sucursal_id = post_response.json()["id"]
 
-    # Actualizar
-    put_response = client.put(f"/sucursales/{sucursal_id}", json={
-        "nombre": "Sucursal Actualizada",
-        "zona": "Zona Actualizada",
-        "direccion": "Dirección Actualizada",
-        "superficie": "95m2"
-    })
+    put_response = client.put(
+        f"/sucursales/{sucursal_id}",
+        json={
+            "nombre": "Sucursal Actualizada",
+            "zona": "Zona Actualizada",
+            "direccion": {
+                "address": "Dirección Actualizada",
+                "lat": 1.0,
+                "lng": 1.0,
+            },
+            "superficie": "95m2",
+        },
+    )
     assert put_response.status_code == 200
     assert put_response.json()["nombre"] == "Sucursal Actualizada"
 
-def test_delete_sucursal():
-    # Crear
-    post_response = client.post("/sucursales/", json={
-        "nombre": "Sucursal para DELETE",
-        "zona": "Zona",
-        "direccion": "Dirección",
-        "superficie": "100m2"
-    })
+
+def test_delete_sucursal(client):
+    post_response = client.post(
+        "/sucursales/",
+        json={
+            "nombre": "Sucursal para DELETE",
+            "zona": "Zona",
+            "direccion": {
+                "address": "Dirección",
+                "lat": 0.0,
+                "lng": 0.0,
+            },
+            "superficie": "100m2",
+        },
+    )
     sucursal_id = post_response.json()["id"]
 
-    # Eliminar
     delete_response = client.delete(f"/sucursales/{sucursal_id}")
     assert delete_response.status_code == 200
     assert "eliminada" in delete_response.json()["message"]
+

--- a/backend/tests/test_controllers/test_zonas.py
+++ b/backend/tests/test_controllers/test_zonas.py
@@ -1,50 +1,38 @@
 import pytest
-from fastapi.testclient import TestClient
-from src.api.routes import app
-from src.config.database import SessionLocal
 
-client = TestClient(app)
 
-def override_get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-app.dependency_overrides = {}
-created_zona_id = None
-
-def test_create_zona():
-    global created_zona_id
-    response = client.post("/zonas/", json={
-        "nombre": "Zona Test"
-    })
+def test_create_zona(client):
+    response = client.post("/zonas/", json={"nombre": "Zona Test"})
     assert response.status_code == 200
     data = response.json()
     assert data["nombre"] == "Zona Test"
     assert "id" in data
-    created_zona_id = data["id"]
 
-def test_create_zona_already_exists():
-    response = client.post("/zonas/", json={
-        "nombre": "Zona Test"
-    })
+
+def test_create_zona_already_exists(client):
+    client.post("/zonas/", json={"nombre": "Zona Test"})
+    response = client.post("/zonas/", json={"nombre": "Zona Test"})
     assert response.status_code == 400
     assert "ya existe" in response.json()["detail"]
 
-def test_listar_zonas():
+
+def test_listar_zonas(client):
+    client.post("/zonas/", json={"nombre": "Zona A"})
     response = client.get("/zonas/")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
-def test_delete_zona():
-    global created_zona_id
-    delete_response = client.delete(f"/zonas/{created_zona_id}")
-    assert delete_response.status_code == 200
-    assert "eliminada" in delete_response.json()["message"]
 
-def test_delete_zona_not_found():
+def test_delete_zona(client):
+    create_resp = client.post("/zonas/", json={"nombre": "Zona Delete"})
+    zona_id = create_resp.json()["id"]
+    delete_resp = client.delete(f"/zonas/{zona_id}")
+    assert delete_resp.status_code == 200
+    assert "eliminada" in delete_resp.json()["message"]
+
+
+def test_delete_zona_not_found(client):
     response = client.delete("/zonas/9999999")
     assert response.status_code == 404
     assert "no encontrada" in response.json()["detail"]
+


### PR DESCRIPTION
## Summary
- configure tests to use temporary SQLite database and shared backend imports
- rewrite sucursales controller tests with structured addresses and fixture-based client
- restructure zonas controller tests to create and clean data within each case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bad42cd1c8328990b98d02c4987e1