### PR TITLE
Add backend unit tests for services and controllers

### DIFF
--- a/backend/tests/test_controllers/test_auth.py
+++ b/backend/tests/test_controllers/test_auth.py
@@ -1,0 +1,9 @@
+from unittest.mock import patch
+
+
+def test_verify_token_endpoint(client):
+    with patch("controllers.auth.verify_user_token", return_value={"ok": True}):
+        response = client.post("/auth/verify", headers={"Authorization": "Bearer token"})
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+

--- a/backend/tests/test_controllers/test_chats.py
+++ b/backend/tests/test_controllers/test_chats.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def test_chat_correctivo_get(client):
+    msg = MagicMock(id=1, firebase_uid="u", nombre_usuario="N", id_mantenimiento=1, texto="t", archivo=None, created_at="now")
+    with patch("controllers.chats.get_chat_correctivo", return_value=[msg]):
+        resp = client.get("/chat/correctivo/1")
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == 1
+
+
+def test_correctivo_message_send(client):
+    msg = MagicMock(id=1, firebase_uid="u", nombre_usuario="N", id_mantenimiento=1, texto="t", archivo=None, created_at="now")
+    with patch("controllers.chats.send_message_correctivo", AsyncMock(return_value=msg)):
+        resp = client.post(
+            "/chat/message-correctivo/1",
+            data={"firebase_uid": "u", "nombre_usuario": "N", "texto": "t"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+

--- a/backend/tests/test_controllers/test_cuadrillas.py
+++ b/backend/tests/test_controllers/test_cuadrillas.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch, MagicMock
+
+
+def test_list_cuadrillas(client):
+    cua = MagicMock(id=1, nombre="Cua", zona="Z", email="c@x.com")
+    with patch("controllers.cuadrillas.get_cuadrillas", return_value=[cua]):
+        resp = client.get("/cuadrillas/")
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == 1
+
+
+def test_get_cuadrilla(client):
+    cua = MagicMock(id=1, nombre="Cua", zona="Z", email="c@x.com")
+    with patch("controllers.cuadrillas.get_cuadrilla", return_value=cua):
+        resp = client.get("/cuadrillas/1")
+    assert resp.status_code == 200
+    assert resp.json()["nombre"] == "Cua"
+

--- a/backend/tests/test_controllers/test_mantenimientos_correctivos.py
+++ b/backend/tests/test_controllers/test_mantenimientos_correctivos.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def test_list_mantenimientos_correctivos(client):
+    m = MagicMock(
+        id=1,
+        id_sucursal=1,
+        id_cuadrilla=1,
+        fecha_apertura="2023-01-01",
+        fecha_cierre=None,
+        numero_caso="1",
+        incidente="i",
+        rubro="r",
+        planilla=None,
+        fotos=[],
+        estado="e",
+        prioridad="p",
+        extendido=None,
+    )
+    with patch("controllers.mantenimientos_correctivos.get_mantenimientos_correctivos", return_value=[m]):
+        resp = client.get("/mantenimientos-correctivos/")
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == 1
+
+
+def test_create_mantenimiento_correctivo(client):
+    m = MagicMock(
+        id=1,
+        id_sucursal=1,
+        id_cuadrilla=1,
+        fecha_apertura="2023-01-01",
+        numero_caso="1",
+        incidente="i",
+        rubro="r",
+        estado="e",
+        prioridad="p",
+    )
+    with patch("controllers.mantenimientos_correctivos.create_mantenimiento_correctivo", AsyncMock(return_value=m)):
+        payload = {
+            "id_sucursal": 1,
+            "id_cuadrilla": 1,
+            "fecha_apertura": "2023-01-01",
+            "numero_caso": "1",
+            "incidente": "Incidente",
+            "rubro": "Otros",
+            "estado": "Pendiente",
+            "prioridad": "Baja",
+        }
+        resp = client.post("/mantenimientos-correctivos/", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+

--- a/backend/tests/test_controllers/test_mantenimientos_preventivos.py
+++ b/backend/tests/test_controllers/test_mantenimientos_preventivos.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def test_list_mantenimientos_preventivos(client):
+    m = MagicMock(
+        id=1,
+        id_sucursal=1,
+        frecuencia="m",
+        id_cuadrilla=1,
+        fecha_apertura="2023-01-01",
+        fecha_cierre=None,
+        planillas=[],
+        fotos=[],
+        extendido=None,
+    )
+    with patch("controllers.mantenimientos_preventivos.get_mantenimientos_preventivos", return_value=[m]):
+        resp = client.get("/mantenimientos-preventivos/")
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == 1
+
+
+def test_create_mantenimiento_preventivo(client):
+    m = MagicMock(id=1, id_sucursal=1, frecuencia="Mensual", id_cuadrilla=1, fecha_apertura="2023-01-01")
+    with patch("controllers.mantenimientos_preventivos.create_mantenimiento_preventivo", AsyncMock(return_value=m)):
+        payload = {"id_sucursal": 1, "frecuencia": "Mensual", "id_cuadrilla": 1, "fecha_apertura": "2023-01-01"}
+        resp = client.post("/mantenimientos-preventivos/", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+

--- a/backend/tests/test_controllers/test_maps.py
+++ b/backend/tests/test_controllers/test_maps.py
@@ -1,0 +1,11 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_sucursales_locations(client):
+    s = SimpleNamespace(id="1", name="S", lat=1.0, lng=2.0)
+    with patch("controllers.maps.get_sucursales_locations", return_value=[s]):
+        resp = client.get("/maps/sucursales-locations")
+    assert resp.status_code == 200
+    assert resp.json() == [{"id": "1", "name": "S", "lat": 1.0, "lng": 2.0}]
+

--- a/backend/tests/test_controllers/test_notificaciones.py
+++ b/backend/tests/test_controllers/test_notificaciones.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def test_notificaciones_correctivos_get(client):
+    n = MagicMock(id=1, firebase_uid="uid", id_mantenimiento=1, mensaje="m", leida=False, created_at="now")
+    with patch("controllers.notificaciones.get_notification_correctivo", return_value=[n]):
+        resp = client.get("/notificaciones/correctivos/uid")
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == 1
+
+
+def test_notificaciones_nearby(client):
+    with patch("controllers.notificaciones.notify_nearby_maintenances", AsyncMock(return_value={"message": "ok"})):
+        payload = {"mantenimientos": [{"id": 1, "tipo": "correctivo", "mensaje": "hola"}]}
+        resp = client.post("/notificaciones/nearby", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "ok"
+

--- a/backend/tests/test_controllers/test_preventivos.py
+++ b/backend/tests/test_controllers/test_preventivos.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch, MagicMock
+
+
+def test_preventivos_get(client):
+    p = MagicMock(id=1, id_sucursal=1, nombre_sucursal="S", frecuencia="Mensual")
+    with patch("controllers.preventivos.get_preventivos", return_value=[p]):
+        resp = client.get("/preventivos/")
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == 1
+
+
+def test_preventivo_create(client):
+    p = MagicMock(id=1, id_sucursal=1, nombre_sucursal="S", frecuencia="Mensual")
+    with patch("controllers.preventivos.create_preventivo", return_value=p):
+        payload = {"id_sucursal": 1, "nombre_sucursal": "S", "frecuencia": "Mensual"}
+        resp = client.post("/preventivos/", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+

--- a/backend/tests/test_controllers/test_push.py
+++ b/backend/tests/test_controllers/test_push.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch, MagicMock
+
+
+def test_push_subscribe(client):
+    with patch("controllers.push.save_subscription", return_value={"message": "saved"}):
+        payload = {
+            "endpoint": "e",
+            "keys": {"p256dh": "p", "auth": "a"},
+            "firebase_uid": "uid",
+            "device_info": "d",
+        }
+        resp = client.post("/push/subscribe", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "saved"
+
+
+def test_push_list(client):
+    sub = MagicMock(id=1, endpoint="e")
+    with patch("controllers.push.get_subscriptions", return_value=[sub]):
+        resp = client.get("/push/subscriptions/uid")
+    assert resp.status_code == 200
+    assert resp.json()[0]["endpoint"] == "e"
+

--- a/backend/tests/test_controllers/test_users.py
+++ b/backend/tests/test_controllers/test_users.py
@@ -1,0 +1,27 @@
+import pytest
+from api.models import Usuario
+from api.schemas import Role
+
+
+def test_list_users(client, db_session):
+    db_session.add(Usuario(nombre="User1", email="u1@example.com", rol=Role.ENCARGADO))
+    db_session.commit()
+    response = client.get("/users/")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert any(user["email"] == "u1@example.com" for user in data)
+
+
+def test_get_user(client, db_session):
+    user = Usuario(nombre="User2", email="u2@example.com", rol=Role.ENCARGADO)
+    db_session.add(user)
+    db_session.commit()
+    response = client.get(f"/users/{user.id}")
+    assert response.status_code == 200
+    assert response.json()["email"] == "u2@example.com"
+
+
+def test_get_user_not_found(client):
+    response = client.get("/users/999")
+    assert response.status_code == 404

--- a/backend/tests/test_services/test_auth.py
+++ b/backend/tests/test_services/test_auth.py
@@ -1,0 +1,13 @@
+import pytest
+from fastapi import HTTPException
+from unittest.mock import patch
+
+from src.services import auth as auth_service
+
+
+def test_verify_user_token_invalid(db_session):
+    with patch.object(auth_service.auth, "verify_id_token", side_effect=Exception("bad")):
+        with pytest.raises(HTTPException) as exc:
+            auth_service.verify_user_token("token", db_session)
+    assert exc.value.status_code == 401
+

--- a/backend/tests/test_services/test_chats.py
+++ b/backend/tests/test_services/test_chats.py
@@ -1,0 +1,16 @@
+import pytest
+from fastapi import HTTPException
+
+from src.services import chats as chat_service
+
+
+def test_get_chat_correctivo_empty(db_session):
+    result = chat_service.get_chat_correctivo(db_session, 1, {"type": "usuario"})
+    assert result == {"message": "No hay mensajes"}
+
+
+def test_get_chat_correctivo_requires_auth(db_session):
+    with pytest.raises(HTTPException) as exc:
+        chat_service.get_chat_correctivo(db_session, 1, None)
+    assert exc.value.status_code == 401
+

--- a/backend/tests/test_services/test_cuadrillas.py
+++ b/backend/tests/test_services/test_cuadrillas.py
@@ -1,0 +1,15 @@
+import pytest
+from fastapi import HTTPException
+
+from src.services import cuadrillas as cuadrillas_service
+
+
+def test_get_cuadrillas_empty(db_session):
+    assert cuadrillas_service.get_cuadrillas(db_session) == []
+
+
+def test_get_cuadrilla_not_found(db_session):
+    with pytest.raises(HTTPException) as exc:
+        cuadrillas_service.get_cuadrilla(db_session, 999)
+    assert exc.value.status_code == 404
+

--- a/backend/tests/test_services/test_gcloud_storage.py
+++ b/backend/tests/test_services/test_gcloud_storage.py
@@ -1,0 +1,14 @@
+import importlib
+import pytest
+from fastapi import HTTPException
+
+from src.services import gcloud_storage
+
+
+def test_create_folder_requires_credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_CREDENTIALS", "{}")
+    importlib.reload(gcloud_storage)
+    with pytest.raises(HTTPException) as exc:
+        gcloud_storage.create_folder_if_not_exists("bucket", "folder")
+    assert exc.value.status_code == 500
+

--- a/backend/tests/test_services/test_google_sheets.py
+++ b/backend/tests/test_services/test_google_sheets.py
@@ -1,0 +1,6 @@
+from src.services import google_sheets
+
+
+def test_get_fotos_gallery_url_returns_none():
+    assert google_sheets.get_fotos_gallery_url(1, "correctivos") is None
+

--- a/backend/tests/test_services/test_mantenimientos_correctivos.py
+++ b/backend/tests/test_services/test_mantenimientos_correctivos.py
@@ -1,0 +1,27 @@
+import pytest
+import asyncio
+import pytest
+from datetime import date
+from fastapi import HTTPException
+
+from src.services import mantenimientos_correctivos as mc
+
+
+def test_create_correctivo_without_auth(db_session):
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            mc.create_mantenimiento_correctivo(
+                db_session,
+                id_sucursal=1,
+                id_cuadrilla=1,
+                fecha_apertura=date.today(),
+                numero_caso="1",
+                incidente="inc",
+                rubro="rubro",
+                estado="abierto",
+                prioridad="baja",
+                current_entity=None,
+            )
+        )
+    assert exc.value.status_code == 401
+

--- a/backend/tests/test_services/test_mantenimientos_preventivos.py
+++ b/backend/tests/test_services/test_mantenimientos_preventivos.py
@@ -1,0 +1,22 @@
+import asyncio
+import pytest
+from datetime import date
+from fastapi import HTTPException
+
+from src.services import mantenimientos_preventivos as mp
+
+
+def test_create_preventivo_without_auth(db_session):
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            mp.create_mantenimiento_preventivo(
+                db_session,
+                id_sucursal=1,
+                frecuencia="Mensual",
+                id_cuadrilla=1,
+                fecha_apertura=date.today(),
+                current_entity=None,
+            )
+        )
+    assert exc.value.status_code == 401
+

--- a/backend/tests/test_services/test_maps.py
+++ b/backend/tests/test_services/test_maps.py
@@ -1,0 +1,15 @@
+import asyncio
+
+from src.services import maps as maps_service
+
+
+def test_get_sucursales_locations_testing_env():
+    result = asyncio.run(maps_service.get_sucursales_locations({"type": "usuario"}))
+    assert result == []
+
+
+def test_update_user_location_message():
+    current = {"type": "usuario", "data": {"id": "1", "uid": "u", "rol": "Admin"}}
+    result = asyncio.run(maps_service.update_user_location(current, "u", "1", "usuario", "User", 1.0, 2.0))
+    assert "message" in result
+

--- a/backend/tests/test_services/test_notificaciones.py
+++ b/backend/tests/test_services/test_notificaciones.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+from src.services import notificaciones as notif_service
+
+
+def test_notify_user_sends_webpush(db_session):
+    with patch("src.services.notificaciones.send_webpush_notification") as mock_push:
+        result = notif_service.notify_user(db_session, "uid", 1, "mensaje", "title", "body")
+        assert result == {"message": "Notification sent"}
+        mock_push.assert_called_once()
+

--- a/backend/tests/test_services/test_preventivos.py
+++ b/backend/tests/test_services/test_preventivos.py
@@ -1,0 +1,17 @@
+import pytest
+from fastapi import HTTPException
+
+from src.services import preventivos as preventivos_service
+
+
+def test_get_preventivo_not_found(db_session):
+    with pytest.raises(HTTPException) as exc:
+        preventivos_service.get_preventivo(db_session, 999)
+    assert exc.value.status_code == 404
+
+
+def test_create_preventivo_requires_auth(db_session):
+    with pytest.raises(HTTPException) as exc:
+        preventivos_service.create_preventivo(db_session, 1, "Sucursal", "mensual", None)
+    assert exc.value.status_code == 401
+

--- a/backend/tests/test_services/test_push_subscriptions.py
+++ b/backend/tests/test_services/test_push_subscriptions.py
@@ -1,0 +1,17 @@
+import pytest
+from fastapi import HTTPException
+
+from src.services import push_subscriptions as ps
+from api.schemas import PushSubscriptionCreate, PushSubscriptionKeys
+
+
+def test_save_subscription_requires_auth(db_session):
+    sub = PushSubscriptionCreate(
+        endpoint="e",
+        keys=PushSubscriptionKeys(p256dh="p", auth="a"),
+        firebase_uid="uid",
+    )
+    with pytest.raises(HTTPException) as exc:
+        ps.save_subscription(db_session, None, sub)
+    assert exc.value.status_code == 401
+

--- a/backend/tests/test_services/test_sucursales.py
+++ b/backend/tests/test_services/test_sucursales.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
 
 os.environ["TESTING"] = "true"
 
@@ -99,3 +100,50 @@ def test_delete_sucursal(db_session):
     # Verificar que no existe más
     with pytest.raises(Exception):
         sucursales_service.get_sucursal(db_session, nueva_sucursal.id)
+
+
+def test_create_sucursal_without_auth(db_session):
+    with pytest.raises(HTTPException) as exc:
+        sucursales_service.create_sucursal(
+            db_session,
+            "Sucursal Fail",
+            "Zona",
+            {"address": "Dirección", "lat": 0, "lng": 0},
+            "100m2",
+            None,
+        )
+    assert exc.value.status_code == 401
+
+
+def test_create_sucursal_invalid_direccion(db_session):
+    with pytest.raises(HTTPException) as exc:
+        sucursales_service.create_sucursal(
+            db_session,
+            "Sucursal Fail",
+            "Zona",
+            "no es un dict",
+            "100m2",
+            {"type": "usuario"},
+        )
+    assert exc.value.status_code == 400
+
+
+def test_update_sucursal_not_found(db_session):
+    with pytest.raises(HTTPException) as exc:
+        sucursales_service.update_sucursal(
+            db_session,
+            999,
+            {"type": "usuario"},
+            nombre="Nueva",
+        )
+    assert exc.value.status_code == 404
+
+
+def test_delete_sucursal_not_found(db_session):
+    with pytest.raises(HTTPException) as exc:
+        sucursales_service.delete_sucursal(
+            db_session,
+            999,
+            {"type": "usuario"},
+        )
+    assert exc.value.status_code == 404

--- a/backend/tests/test_services/test_users.py
+++ b/backend/tests/test_services/test_users.py
@@ -1,0 +1,61 @@
+import pytest
+from fastapi import HTTPException
+from src.services import users as users_service
+from api.models import Usuario
+from api.schemas import Role
+
+
+def test_get_users_requires_auth(db_session):
+    with pytest.raises(HTTPException) as exc:
+        users_service.get_users(db_session, None)
+    assert exc.value.status_code == 401
+
+
+def test_get_users_requires_admin(db_session):
+    with pytest.raises(HTTPException) as exc:
+        users_service.get_users(db_session, {"type": "usuario", "data": {"rol": Role.ENCARGADO}})
+    assert exc.value.status_code == 403
+
+
+def test_get_users_success(db_session):
+    db_session.add(Usuario(nombre="User1", email="u1@example.com", rol=Role.ENCARGADO))
+    db_session.commit()
+    users = users_service.get_users(db_session, {"type": "usuario", "data": {"rol": Role.ADMIN}})
+    assert len(users) == 1
+
+
+def test_get_user_requires_auth(db_session):
+    with pytest.raises(HTTPException) as exc:
+        users_service.get_user(db_session, 1, None)
+    assert exc.value.status_code == 401
+
+
+def test_get_user_not_found(db_session):
+    with pytest.raises(HTTPException) as exc:
+        users_service.get_user(db_session, 999, {"type": "usuario", "data": {"rol": Role.ADMIN}})
+    assert exc.value.status_code == 404
+
+
+def test_get_user_no_permission(db_session):
+    user = Usuario(nombre="User2", email="u2@example.com", rol=Role.ENCARGADO)
+    db_session.add(user)
+    db_session.commit()
+    with pytest.raises(HTTPException) as exc:
+        users_service.get_user(
+            db_session,
+            user.id,
+            {"type": "usuario", "data": {"id": 999, "rol": Role.ENCARGADO}},
+        )
+    assert exc.value.status_code == 403
+
+
+def test_get_user_admin_success(db_session):
+    user = Usuario(nombre="User3", email="u3@example.com", rol=Role.ENCARGADO)
+    db_session.add(user)
+    db_session.commit()
+    result = users_service.get_user(
+        db_session,
+        user.id,
+        {"type": "usuario", "data": {"rol": Role.ADMIN}},
+    )
+    assert result.email == "u3@example.com"

--- a/backend/tests/test_services/test_webpush.py
+++ b/backend/tests/test_services/test_webpush.py
@@ -1,0 +1,11 @@
+import importlib
+
+import src.services.webpush as webpush_service
+
+
+def test_send_webpush_not_configured(monkeypatch, db_session):
+    monkeypatch.delenv("VAPID_PRIVATE_KEY", raising=False)
+    importlib.reload(webpush_service)
+    result = webpush_service.send_webpush_notification(db_session, "uid", "title", "body")
+    assert result == {"message": "Web push not configured"}
+

--- a/backend/tests/test_services/test_zonas.py
+++ b/backend/tests/test_services/test_zonas.py
@@ -77,3 +77,25 @@ def test_delete_zona_in_use(db_session, mocker):
         )
     assert exc.value.status_code == 400
     assert "está en uso" in exc.value.detail
+
+
+def test_create_zona_without_auth(db_session):
+    with pytest.raises(HTTPException) as exc:
+        zonas_service.create_zona(db_session, nombre="Zona", current_entity=None)
+    assert exc.value.status_code == 401
+
+
+def test_create_zona_no_permissions(db_session):
+    with pytest.raises(HTTPException) as exc:
+        zonas_service.create_zona(
+            db_session,
+            nombre="Zona",
+            current_entity={"type": "cuadrilla"},
+        )
+    assert exc.value.status_code == 403
+
+
+def test_delete_zona_not_found(db_session):
+    with pytest.raises(HTTPException) as exc:
+        zonas_service.delete_zona(db_session, 999, current_entity={"type": "usuario"})
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary
- add tests for auth, chats, cuadrillas, mantenimientos, maps, notificaciones, preventivos and push controllers
- cover auth, chats, cuadrillas, gcloud storage, google sheets, mantenimientos, maps, notificaciones, preventivos, push subscriptions and webpush services

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd0a415408328b11caebe3debff32