### PR TITLE
chore: setup vitest and add component tests

### DIFF
--- a/frontend/tests/components/BackButton.test.tsx
+++ b/frontend/tests/components/BackButton.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import BackButton from '../../src/components/BackButton';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('BackButton component', () => {
+  test('navigates to provided path when "to" prop is set', () => {
+    render(
+      <MemoryRouter>
+        <BackButton to="/home" label="Volver" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /volver/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/home');
+  });
+
+  test('navigates back when no "to" prop is provided', () => {
+    render(
+      <MemoryRouter>
+        <BackButton label="Regresar" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /regresar/i }));
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+});
+

--- a/frontend/tests/components/SucursalForm.test.tsx
+++ b/frontend/tests/components/SucursalForm.test.tsx
@@ -9,6 +9,14 @@ import * as sucursalService from '../../src/services/sucursalService';
 vi.mock('../../src/services/zonaService');
 vi.mock('../../src/services/sucursalService');
 vi.mock('../../src/services/api');
+vi.mock('../../src/components/DirreccionAutocomplete', () => ({
+  default: ({ onSelect }) => (
+    <input
+      placeholder="Escriba una dirección"
+      onChange={() => onSelect({ address: 'Calle Falsa 123', lat: 1, lng: 1 })}
+    />
+  ),
+}));
 
 describe('SucursalForm component', () => {
   const sucursalMock = {
@@ -23,6 +31,7 @@ describe('SucursalForm component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    zonaService.getZonas.mockResolvedValue({ data: [] });
   });
 
   test('renderiza correctamente el formulario para crear', async () => {
@@ -30,7 +39,7 @@ describe('SucursalForm component', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText(/Nombre/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/Dirección/i)).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/Escriba una dirección/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/Superficie/i)).toBeInTheDocument();
     });
 
@@ -43,7 +52,7 @@ describe('SucursalForm component', () => {
     render(<SucursalForm onClose={mockOnSave} />);
 
     fireEvent.change(screen.getByLabelText(/Nombre/i), { target: { value: 'Sucursal Nueva' } });
-    fireEvent.change(screen.getByLabelText(/Dirección/i), { target: { value: 'Calle Falsa 123' } });
+    fireEvent.change(screen.getByPlaceholderText(/Escriba una dirección/i), { target: { value: 'Calle Falsa 123' } });
     fireEvent.change(screen.getByLabelText(/Superficie/i), { target: { value: '300' } });
 
     fireEvent.click(screen.getByText(/Seleccione una zona/i));
@@ -69,7 +78,7 @@ describe('SucursalForm component', () => {
     
     expect(screen.getByDisplayValue('Sucursal Centro')).toBeInTheDocument();
     expect(screen.getByText('Zona 1')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('Calle Falsa 123')).toBeInTheDocument();
+    expect(screen.getByText(/Seleccionado: Calle Falsa 123/i)).toBeInTheDocument();
     expect(screen.getByDisplayValue('300')).toBeInTheDocument();
   });
   
@@ -132,3 +141,4 @@ describe('SucursalForm component', () => {
     });
   });
 });
+

--- a/frontend/tests/pages/Sucursales.test.tsx
+++ b/frontend/tests/pages/Sucursales.test.tsx
@@ -4,6 +4,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import Sucursales from '../../src/pages/Sucursales';
 import * as sucursalService from '../../src/services/sucursalService';
 import * as zonaService from '../../src/services/zonaService';
+import { BrowserRouter } from 'react-router-dom';
 
 // Mocks
 vi.mock('../../src/services/sucursalService');
@@ -25,7 +26,11 @@ describe('Sucursales component', () => {
   });
 
   test('muestra sucursales en la tabla', async () => {
-    render(<Sucursales />);
+    render(
+      <BrowserRouter>
+        <Sucursales />
+      </BrowserRouter>
+    );
 
     expect(screen.getByText('Gestión de Sucursales')).toBeInTheDocument();
 
@@ -36,7 +41,11 @@ describe('Sucursales component', () => {
   });
 
   test('al hacer click en Agregar muestra el formulario', async () => {
-    render(<Sucursales />);
+    render(
+      <BrowserRouter>
+        <Sucursales />
+      </BrowserRouter>
+    );
 
     fireEvent.click(screen.getByText(/Agregar/i));
 
@@ -51,7 +60,11 @@ describe('Sucursales component', () => {
     });
     sucursalService.deleteSucursal.mockResolvedValue({});
 
-    render(<Sucursales />);
+    render(
+      <BrowserRouter>
+        <Sucursales />
+      </BrowserRouter>
+    );
 
     const eliminarButton = await screen.findByRole('button', { name: /Eliminar/i });
     fireEvent.click(eliminarButton);
@@ -66,7 +79,11 @@ describe('Sucursales component', () => {
       data: [{ id: 1, nombre: 'Sucursal 2', zona: 'Zona B', direccion: 'Avenida 456', superficie: '200' }],
     });
 
-    render(<Sucursales />);
+    render(
+      <BrowserRouter>
+        <Sucursales />
+      </BrowserRouter>
+    );
 
     const editarButton = await screen.findByRole('button', { name: /Editar/i });
     fireEvent.click(editarButton);
@@ -74,4 +91,5 @@ describe('Sucursales component', () => {
     expect(await screen.findByDisplayValue('Sucursal 2')).toBeInTheDocument();
   });  
 });
+
 

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,9 +1,18 @@
 /// <reference types="vitest" />
 
-import { afterEach } from "vitest";
+import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+vi.mock('../src/services/firebase', () => ({
+  auth: {},
+  signOut: vi.fn(),
+  getPushSubscription: vi.fn(),
+  signInWithCredential: vi.fn(),
+  GoogleAuthProvider: { credential: vi.fn() },
+}));
+
 afterEach(() => {
-    cleanup();
+  cleanup();
 });
+

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,8 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   test: {
-      environment: 'jsdom',
-      setupFiles: './src/tests/setup.js'
-  }
+    environment: 'jsdom',
+    setupFiles: './tests/setup.ts',
+    globals: true,
+  },
 })


### PR DESCRIPTION
## Summary
- fix Vitest config to use TypeScript setup file
- mock Firebase in test setup and expand component coverage
- wrap Sucursales page tests with router context

## Testing
- `npm test -- --run` *(fails: Cannot destructure property 'currentEntity' of 'useContext(...)' as it is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a1209df8788328ad52be864501706f