### PR TITLE
refactor: externalize DireccionAutocomplete styles

### DIFF
--- a/frontend/src/components/DireccionAutocomplete.jsx
+++ b/frontend/src/components/DireccionAutocomplete.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import usePlacesAutocomplete, { getGeocode, getLatLng } from 'use-places-autocomplete';
+import '../styles/direccion-autocomplete.css';
 
 const DireccionAutocomplete = ({ onSelect }) => {
   const {
@@ -28,34 +29,21 @@ const DireccionAutocomplete = ({ onSelect }) => {
   };
 
   return (
-    <div style={{ position: 'relative' }}>
+    <div className="direccion-autocomplete">
       <input
         value={value}
         onChange={handleInput}
         disabled={!ready}
         placeholder="Escriba una dirección"
-        style={{ width: '100%', padding: '8px' }}
+        className="direccion-autocomplete-input"
       />
       {status === 'OK' && (
-        <ul
-          style={{
-            position: 'absolute',
-            zIndex: 1000,
-            backgroundColor: 'white',
-            width: '100%',
-            border: '1px solid #ccc',
-            marginTop: '4px',
-            maxHeight: '200px',
-            overflowY: 'auto',
-            listStyle: 'none',
-            padding: 0,
-          }}
-        >
+        <ul className="direccion-autocomplete-suggestions">
           {data.map(({ place_id, description }) => (
             <li
               key={place_id}
               onClick={() => handleSelect(description)}
-              style={{ padding: '8px', cursor: 'pointer' }}
+              className="direccion-autocomplete-item"
             >
               {description}
             </li>

--- a/frontend/src/components/SucursalForm.jsx
+++ b/frontend/src/components/SucursalForm.jsx
@@ -3,7 +3,7 @@ import { Modal, Button, Form, InputGroup, Dropdown } from 'react-bootstrap';
 import { createSucursal, updateSucursal } from '../services/sucursalService';
 import { getZonas, createZona, deleteZona } from '../services/zonaService';
 import { FaPlus } from 'react-icons/fa';
-import DireccionAutocomplete from './DirreccionAutocomplete';
+import DireccionAutocomplete from './DireccionAutocomplete';
 import '../styles/formularios.css';
 
 const SucursalForm = ({ sucursal, onClose }) => {

--- a/frontend/src/styles/direccion-autocomplete.css
+++ b/frontend/src/styles/direccion-autocomplete.css
@@ -1,0 +1,26 @@
+.direccion-autocomplete {
+  position: relative;
+}
+
+.direccion-autocomplete-input {
+  width: 100%;
+  padding: 8px;
+}
+
+.direccion-autocomplete-suggestions {
+  position: absolute;
+  z-index: 1000;
+  background-color: white;
+  width: 100%;
+  border: 1px solid #ccc;
+  margin-top: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  list-style: none;
+  padding: 0;
+}
+
+.direccion-autocomplete-item {
+  padding: 8px;
+  cursor: pointer;
+}

--- a/frontend/tests/components/SucursalForm.test.tsx
+++ b/frontend/tests/components/SucursalForm.test.tsx
@@ -11,7 +11,7 @@ import * as sucursalService from '../../src/services/sucursalService';
 vi.mock('../../src/services/zonaService');
 vi.mock('../../src/services/sucursalService');
 vi.mock('../../src/services/api');
-vi.mock('../../src/components/DirreccionAutocomplete', () => ({
+vi.mock('../../src/components/DireccionAutocomplete', () => ({
   default: ({ onSelect }) => (
     <input
       placeholder="Escriba una dirección"


### PR DESCRIPTION
## Summary
- rename DirreccionAutocomplete to DireccionAutocomplete
- move inline styles to direccion-autocomplete.css and use CSS classes
- update component and test imports

## Testing
- `npm test -- --run` (fails: 5 failed, 6 passed)


------
https://chatgpt.com/codex/tasks/task_e_68ab6cbba6c08328910b7c50cd8badd8