### PR TITLE
refactor: centralize layout and route configuration

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,103 +1,53 @@
 import React, { useContext, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import { AuthProvider, AuthContext } from './context/AuthContext';
 import LocationProvider from './context/LocationContext';
-import Navbar from './components/Navbar';
-import Footer from './components/Footer';
-import Home from './pages/Home';
-import Users from './pages/Users';
-import Sucursales from './pages/Sucursales';
-import Cuadrillas from './pages/Cuadrillas';
-import Mantenimiento from './pages/Mantenimiento';
-import MantenimientoPreventivo from './pages/MantenimientosPreventivos';
-import MantenimientoCorrectivo from './pages/MantenimientosCorrectivos';
-import Preventivo from './pages/Preventivo';
-import Correctivo from './pages/Correctivo';
 import Login from './pages/Login';
-import Mapa from './pages/Mapa';
-import Ruta from './pages/Ruta';
-import Reportes from './pages/Reportes';
-import BackButton from './components/BackButton';
 import { mapsApiKey } from './config';
 import { LoadScript } from '@react-google-maps/api';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-routing-machine/dist/leaflet-routing-machine.css';
+import ProtectedRoute from './components/ProtectedRoute';
+import Layout from './components/Layout';
+import routes from './routes';
 
 const googleMapsLibraries = ['places'];
-
-const ProtectedRoute = ({ children, adminOnly, usersOnly }) => {
-  const { currentEntity, loading, verifying } = useContext(AuthContext);
-  const location = useLocation();
-
-  if (loading || verifying) {
-    return (
-      <div className="d-flex justify-content-center align-items-center min-vh-100">
-        <div className="spinner-border" role="status">
-          <span className="visually-hidden">Cargando...</span>
-        </div>
-      </div>
-    );
-  }
-
-  if (!currentEntity) {
-    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
-  }
-
-  if (adminOnly && (currentEntity.type !== 'usuario' || currentEntity.data.rol !== 'Administrador')) {
-    return <Navigate to="/" replace />;
-  }
-
-  if (usersOnly && currentEntity.type !== 'usuario') {
-    return <Navigate to="/" replace />;
-  }
-
-  return children;
-};
 
 const AppContent = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { currentEntity, loading, verifying } = useContext(AuthContext);
-  const isLoginPage = location.pathname === '/login';
-  const isHomePage = location.pathname === '/';
-  const isCorrectivoPage = location.pathname === '/correctivo' || location.pathname === '/mantenimientos-correctivos';
-  const isPreventivoPage = location.pathname === '/preventivo' || location.pathname === '/mantenimientos-preventivos';
-  const isMantenimientoPage = location.pathname === '/mantenimiento';
-  const isRutaPage = location.pathname === '/ruta';
 
   useEffect(() => {
-    if (currentEntity && !loading && !verifying && isLoginPage) {
+    if (currentEntity && !loading && !verifying && location.pathname === '/login') {
       const redirectTo = location.state?.from || '/';
       navigate(redirectTo, { replace: true });
     }
-  }, [currentEntity, loading, verifying, isLoginPage, navigate, location]);
+  }, [currentEntity, loading, verifying, location, navigate]);
 
   return (
     <LoadScript googleMapsApiKey={mapsApiKey} libraries={googleMapsLibraries}>
-      <div className="d-flex flex-column min-vh-100">
-        {!isLoginPage && <Navbar />}
-        <main className="flex-grow-1">
-          {!isLoginPage && !isHomePage && !isCorrectivoPage && !isPreventivoPage && !isMantenimientoPage && !isRutaPage &&(
-            <BackButton />)}
-          <Routes>
-            <Route path="/" element={<ProtectedRoute><Home /></ProtectedRoute>} />
-            <Route path="/mantenimiento" element={<ProtectedRoute><Mantenimiento /></ProtectedRoute>} />
-            <Route path="/users" element={<ProtectedRoute adminOnly><Users /></ProtectedRoute>} />
-            <Route path="/sucursales" element={<ProtectedRoute usersOnly><Sucursales /></ProtectedRoute>} />
-            <Route path="/cuadrillas" element={<ProtectedRoute usersOnly><Cuadrillas /></ProtectedRoute>} />
-            <Route path="/mantenimientos-preventivos" element={<ProtectedRoute><MantenimientoPreventivo /></ProtectedRoute>} />
-            <Route path="/mantenimientos-correctivos" element={<ProtectedRoute><MantenimientoCorrectivo /></ProtectedRoute>} />
-            <Route path="/preventivo" element={<ProtectedRoute><Preventivo /></ProtectedRoute>} />
-            <Route path="/correctivo" element={<ProtectedRoute><Correctivo /></ProtectedRoute>} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/mapa" element={<ProtectedRoute usersOnly><Mapa /></ProtectedRoute>} />
-            <Route path="/ruta" element={<ProtectedRoute><Ruta /></ProtectedRoute>} />
-            <Route path="/reportes" element={<ProtectedRoute adminOnly><Reportes /></ProtectedRoute>} />
-          </Routes>
-        </main>
-        {!isLoginPage && <Footer />}
-      </div>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
+          {routes.map(({ path, element, adminOnly, usersOnly }) => (
+            <Route
+              key={path}
+              path={path}
+              element={
+                adminOnly || usersOnly ? (
+                  <ProtectedRoute adminOnly={adminOnly} usersOnly={usersOnly}>
+                    {element}
+                  </ProtectedRoute>
+                ) : (
+                  element
+                )
+              }
+            />
+          ))}
+        </Route>
+      </Routes>
     </LoadScript>
   );
 };
@@ -106,9 +56,9 @@ function App() {
   return (
     <Router>
       <AuthProvider>
-          <LocationProvider>
-            <AppContent />
-          </LocationProvider>
+        <LocationProvider>
+          <AppContent />
+        </LocationProvider>
       </AuthProvider>
     </Router>
   );

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import BackButton from './BackButton';
+import routes from '../routes';
+
+const Layout = () => {
+  const location = useLocation();
+  const currentRoute = routes.find((r) => r.path === location.pathname);
+  const showBackButton = !(currentRoute && currentRoute.hideBackButton);
+
+  return (
+    <div className="d-flex flex-column min-vh-100">
+      <Navbar />
+      <main className="flex-grow-1">
+        {showBackButton && <BackButton />}
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Layout;

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+const ProtectedRoute = ({ children, adminOnly, usersOnly }) => {
+  const { currentEntity, loading, verifying } = useContext(AuthContext);
+  const location = useLocation();
+
+  if (loading || verifying) {
+    return (
+      <div className="d-flex justify-content-center align-items-center min-vh-100">
+        <div className="spinner-border" role="status">
+          <span className="visually-hidden">Cargando...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!currentEntity) {
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+  }
+
+  if (adminOnly && (currentEntity.type !== 'usuario' || currentEntity.data.rol !== 'Administrador')) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (usersOnly && currentEntity.type !== 'usuario') {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Home from './pages/Home';
+import Users from './pages/Users';
+import Sucursales from './pages/Sucursales';
+import Cuadrillas from './pages/Cuadrillas';
+import Mantenimiento from './pages/Mantenimiento';
+import MantenimientoPreventivo from './pages/MantenimientosPreventivos';
+import MantenimientoCorrectivo from './pages/MantenimientosCorrectivos';
+import Preventivo from './pages/Preventivo';
+import Correctivo from './pages/Correctivo';
+import Mapa from './pages/Mapa';
+import Ruta from './pages/Ruta';
+import Reportes from './pages/Reportes';
+
+const routes = [
+  { path: '/', element: <Home />, hideBackButton: true },
+  { path: '/mantenimiento', element: <Mantenimiento />, hideBackButton: true },
+  { path: '/users', element: <Users />, adminOnly: true },
+  { path: '/sucursales', element: <Sucursales />, usersOnly: true },
+  { path: '/cuadrillas', element: <Cuadrillas />, usersOnly: true },
+  { path: '/mantenimientos-preventivos', element: <MantenimientoPreventivo />, hideBackButton: true },
+  { path: '/mantenimientos-correctivos', element: <MantenimientoCorrectivo />, hideBackButton: true },
+  { path: '/preventivo', element: <Preventivo />, hideBackButton: true },
+  { path: '/correctivo', element: <Correctivo />, hideBackButton: true },
+  { path: '/mapa', element: <Mapa />, usersOnly: true },
+  { path: '/ruta', element: <Ruta />, hideBackButton: true },
+  { path: '/reportes', element: <Reportes />, adminOnly: true },
+];
+
+export default routes;


### PR DESCRIPTION
## Summary
- extract `ProtectedRoute` into its own component
- add main layout with `Navbar`, `Footer` and `BackButton`
- map application routes from a configuration array

## Testing
- `pytest`
- `npm run test:run` *(fails: Unable to find an accessible element with the role "button" and name `/guardar/i`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6ccf18d083288810147c03a82384