### PR TITLE
feat: add auth role hook and home button

### DIFF
--- a/frontend/src/components/HomeButton.jsx
+++ b/frontend/src/components/HomeButton.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuthRoles } from '../hooks/useAuthRoles';
+
+const HomeButton = ({ to, icon: Icon, children, requiredRoles = [] }) => {
+  const { isAdmin, isUser, isCuadrilla } = useAuthRoles();
+  const roles = {
+    admin: isAdmin,
+    user: isUser,
+    cuadrilla: isCuadrilla,
+  };
+
+  const allowed = Array.isArray(requiredRoles) ? requiredRoles : [requiredRoles];
+  const hasPermission = allowed.length === 0 ? true : allowed.some(role => roles[role]);
+  if (!hasPermission) return null;
+
+  return (
+    <Link to={to} className="home-button">
+      <Icon />
+      {children}
+    </Link>
+  );
+};
+
+export default HomeButton;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,12 +4,15 @@ import { Navbar as BootstrapNavbar, Nav, Container, Image, Modal, Button } from 
 import logoInversur from '../assets/logo_inversur.png';
 import { FaBell, FaTimes } from 'react-icons/fa';
 import { AuthContext } from '../context/AuthContext';
+import { useAuthRoles } from '../hooks/useAuthRoles';
 import { get_notificaciones_correctivos, get_notificaciones_preventivos, correctivo_leido, preventivo_leido, delete_notificacion } from '../services/notificaciones';
 import { subscribeToNotifications } from '../services/notificationWs';
 import '../styles/navbar.css';
 
 const Navbar = () => {
   const { currentEntity, logOut } = useContext(AuthContext);
+  const { isAdmin, isUser, isCuadrilla } = useAuthRoles();
+  const isLogged = isUser || isCuadrilla;
   const socketRef = useRef(null);
   const navigate = useNavigate();
   const [showNotifications, setShowNotifications] = useState(false);
@@ -217,25 +220,25 @@ const Navbar = () => {
          {/* <BootstrapNavbar.Toggle aria-controls="basic-navbar-nav" />*/}
           {/*<BootstrapNavbar.Collapse id="basic-navbar-nav">*/}
             <Nav className="me-auto custom-nav-links">
-              {currentEntity && currentEntity.type === 'usuario' && currentEntity.data.rol === 'Administrador' && (
+              {isAdmin && (
                 <>
                   <Nav.Link as={Link} to="/users">Usuarios</Nav.Link>
                 </>
               )}
-              {currentEntity && currentEntity.type === 'usuario' && (
+              {isUser && (
                 <>
                   <Nav.Link as={Link} to="/cuadrillas">Cuadrillas</Nav.Link>
                   <Nav.Link as={Link} to="/sucursales">Sucursales</Nav.Link>
                 </>
               )}
-              {currentEntity && (
+              {isLogged && (
                 <>
                   <Nav.Link as={Link} to="/mantenimientos-preventivos">Mantenimientos Preventivos</Nav.Link>
                   <Nav.Link as={Link} to="/mantenimientos-correctivos">Mantenimientos Correctivos</Nav.Link>
                   <Nav.Link /*as={Link} to="/mapas"*/>Mapa</Nav.Link>
                 </>
               )}
-              {currentEntity && currentEntity.type === 'usuario' && currentEntity.data.rol === 'Administrador' && (
+              {isAdmin && (
                 <>
                   <Nav.Link /*as={Link} to="/reportes"*/>Reportes</Nav.Link>
                 </>

--- a/frontend/src/hooks/useAuthRoles.js
+++ b/frontend/src/hooks/useAuthRoles.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { AuthContext } from '../context/AuthContext';
+
+export const useAuthRoles = () => {
+  const { currentEntity } = useContext(AuthContext);
+  const isUser = currentEntity?.type === 'usuario';
+  const isCuadrilla = currentEntity?.type === 'cuadrilla';
+  const isAdmin = isUser && currentEntity?.data?.rol === 'Administrador';
+  return { isAdmin, isUser, isCuadrilla };
+};
+
+export default useAuthRoles;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,46 +1,28 @@
-import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
-import { AuthContext } from '../context/AuthContext';
+import React from 'react';
 import { FaUsers, FaClipboardList, FaMapMarkerAlt, FaFileAlt } from 'react-icons/fa';
+import HomeButton from '../components/HomeButton';
 import '../styles/home.css';
 
 const Home = () => {
-  const { currentEntity } = useContext(AuthContext);
-
   return (
     <div className="home-container">
       <div className="page-content">
         <div className="button-home-container">
-          {currentEntity && currentEntity.type === 'usuario' && currentEntity.data.rol === 'Administrador' && (
-            <Link to="/users" className="home-button">
-              <FaUsers />
-              Usuarios
-            </Link>
-          )}
-          {currentEntity && (
-            <Link to="/mantenimiento" className="home-button">
-              <FaClipboardList />
-              Mantenimiento
-            </Link>
-          )}
-          {currentEntity && currentEntity.type === 'usuario' && (
-            <Link to="/mapa" className="home-button">
-              <FaMapMarkerAlt />
-              Mapa
-            </Link>
-          )}
-          {currentEntity && currentEntity.type === 'cuadrilla' && (
-            <Link to="/ruta" className="home-button">
-              <FaMapMarkerAlt />
-              Mapa
-            </Link>
-          )}
-          {currentEntity && currentEntity.type === 'usuario' && currentEntity.data.rol === 'Administrador' && (
-            <Link to="/reportes" className="home-button">
-              <FaFileAlt />
-              Reportes
-            </Link>
-          )}
+          <HomeButton to="/users" icon={FaUsers} requiredRoles="admin">
+            Usuarios
+          </HomeButton>
+          <HomeButton to="/mantenimiento" icon={FaClipboardList} requiredRoles={["user", "cuadrilla"]}>
+            Mantenimiento
+          </HomeButton>
+          <HomeButton to="/mapa" icon={FaMapMarkerAlt} requiredRoles="user">
+            Mapa
+          </HomeButton>
+          <HomeButton to="/ruta" icon={FaMapMarkerAlt} requiredRoles="cuadrilla">
+            Mapa
+          </HomeButton>
+          <HomeButton to="/reportes" icon={FaFileAlt} requiredRoles="admin">
+            Reportes
+          </HomeButton>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `useAuthRoles` hook to expose role booleans
- replace verbose role checks with hook variables and new `HomeButton` component
- streamline navbar links with role flags

## Testing
- `npm test` *(fails: SucursalForm.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6cee9f248328a5cc99f438aa2271