### PR TITLE
refactor: extract notifications hook and item

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,29 +1,26 @@
-import React, { useState, useContext, useEffect, useRef } from 'react';
+import React, { useState, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Navbar as BootstrapNavbar, Nav, Container, Image, Modal, Button } from 'react-bootstrap';
 import logoInversur from '../assets/logo_inversur.png';
-import { FaBell, FaTimes } from 'react-icons/fa';
+import { FaBell } from 'react-icons/fa';
 import { AuthContext } from '../context/AuthContext';
-import { get_notificaciones_correctivos, get_notificaciones_preventivos, correctivo_leido, preventivo_leido, delete_notificacion } from '../services/notificaciones';
-import { subscribeToNotifications } from '../services/notificationWs';
+import { correctivo_leido, preventivo_leido, delete_notificacion } from '../services/notificaciones';
+import useNotifications from '../hooks/useNotifications';
+import NotificationItem from './NotificationItem';
 import '../styles/navbar.css';
 
 const Navbar = () => {
   const { currentEntity, logOut } = useContext(AuthContext);
-  const socketRef = useRef(null);
   const navigate = useNavigate();
   const [showNotifications, setShowNotifications] = useState(false);
-  const [notifications, setNotifications] = useState([]);
-  const [unreadCount, setUnreadCount] = useState(0);
+  const { notifications, unreadCount, fetchNotifications, disconnect } = useNotifications();
 
   const handleShowNotifications = () => setShowNotifications(true);
   const handleCloseNotifications = () => setShowNotifications(false);
 
   const handleLogout = async () => {
     try {
-      if (socketRef.current?.close) socketRef.current.close();
-      else if (socketRef.current?.disconnect) socketRef.current.disconnect();
-      socketRef.current = null;
+      disconnect();
       await logOut();
     } catch (error) {
       console.error('Error al cerrar sesión:', error);
@@ -55,70 +52,6 @@ const Navbar = () => {
     return result.trim();
   };
 
-  const fetchNotifications = async () => {
-    try {
-      const uid = currentEntity?.data?.uid;
-      if (!uid) return;
-
-      const [correctivosResp, preventivosResp] = await Promise.all([
-        get_notificaciones_correctivos(uid),
-        get_notificaciones_preventivos(uid)
-      ]);
-
-      const correctivos = Array.isArray(correctivosResp.data) ? correctivosResp.data : [];
-      const preventivos = Array.isArray(preventivosResp.data) ? preventivosResp.data : [];
-
-      const mappedCorrectivos = correctivos.map((notif) => ({
-        ...notif,
-        tipo: 'correctivo'
-      }));
-
-      const mappedPreventivos = preventivos.map((notif) => ({
-        ...notif,
-        tipo: 'preventivo'
-      }));
-
-      const allNotificaciones = [...mappedCorrectivos, ...mappedPreventivos];
-      setUnreadCount(allNotificaciones.filter(n => !n.leida).length);
-
-      // Ordenar por fecha descendente
-      allNotificaciones.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-
-      setNotifications(allNotificaciones);
-    } catch (error) {
-      console.error('Error obteniendo notificaciones:', error);
-    }
-  };
-
-  useEffect(() => {
-    if (currentEntity?.data?.uid) fetchNotifications();
-  }, [currentEntity?.data?.uid]);
-
-  useEffect(() => {
-    const uid = currentEntity?.data?.uid;
-    if (!uid) return;
-
-    // Evita depender de WebSocket en JSDOM
-    const OPEN = typeof WebSocket !== 'undefined' ? WebSocket.OPEN : 1;
-    if (socketRef.current && socketRef.current.readyState === OPEN) return;
-
-    const onMessage = (data) => {
-      setNotifications((prev) => {
-        const updated = [data, ...prev];
-        setUnreadCount(updated.filter((n) => !n.leida).length);
-        return updated;
-      });
-    };
-
-    const socket = subscribeToNotifications(uid, onMessage);
-    socketRef.current = socket;
-
-    return () => {
-      if (socketRef.current?.close) socketRef.current.close();
-      else if (socketRef.current?.disconnect) socketRef.current.disconnect();
-      socketRef.current = null;
-    };
-  }, [currentEntity?.data?.uid]);
 
   const handleClick = async (notification) => {
     if (notification.tipo === 'correctivo') {
@@ -136,8 +69,7 @@ const Navbar = () => {
     }
   };
 
-  const handleDeleteNotification = async (notificationId, e) => {
-    e.stopPropagation();
+  const handleDeleteNotification = async (notificationId) => {
     try {
       await delete_notificacion(notificationId);
       await fetchNotifications();
@@ -162,35 +94,6 @@ const Navbar = () => {
     }
   };
 
-  const renderNotification = (notification, index) => (
-    <div 
-      key={index} 
-      onClick={() => handleClick(notification)} 
-      className="mb-3 p-2 border-bottom hover:bg-gray-100 p-2 rounded d-flex align-items-center"
-    >
-      <div className="flex-grow-1">
-        <p className="mb-1">{notification.mensaje}</p>
-        <small className="text-muted">{timeAgo(notification.created_at)}</small>
-      </div>
-      <div className="d-flex align-items-center">
-        {!notification.leida && (
-          <span 
-            className="bg-warning rounded-circle"
-            style={{ width: '10px', height: '10px', marginLeft: '10px' }}
-          ></span>
-        )}
-        <Button
-          aria-label="Eliminar notificación"
-          variant="outline-danger"
-          size="sm"
-          onClick={(e) => handleDeleteNotification(notification.id, e)}
-          className="ms-2"
-        >
-          <FaTimes />
-        </Button>
-      </div>
-    </div>
-  );
 
   const handleDeleteReadNotifications = async () => {
     try {
@@ -292,14 +195,30 @@ const Navbar = () => {
               )}
               {notifications
                 .filter(n => n.tipo === 'correctivo')
-                .map((notification, index) => renderNotification(notification, index))}
+                .map((notification, index) => (
+                  <NotificationItem
+                    key={index}
+                    notification={notification}
+                    timeAgo={timeAgo}
+                    onClick={handleClick}
+                    onDelete={handleDeleteNotification}
+                  />
+                ))}
 
               {notifications.some(n => n.tipo === 'preventivo') && (
                 <h6 className="mt-3 mb-1 text-muted">Preventivos</h6>
               )}
               {notifications
                 .filter(n => n.tipo === 'preventivo')
-                .map((notification, index) => renderNotification(notification, index))}
+                .map((notification, index) => (
+                  <NotificationItem
+                    key={index}
+                    notification={notification}
+                    timeAgo={timeAgo}
+                    onClick={handleClick}
+                    onDelete={handleDeleteNotification}
+                  />
+                ))}
             </>
           ) : (
             <p>No tienes notificaciones.</p>

--- a/frontend/src/components/NotificationItem.jsx
+++ b/frontend/src/components/NotificationItem.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+import { FaTimes } from 'react-icons/fa';
+
+const NotificationItem = ({ notification, timeAgo, onClick, onDelete }) => {
+  const handleContainerClick = (e) => {
+    if (e.target.closest('.delete-notification-btn')) return;
+    onClick(notification);
+  };
+
+  return (
+    <div
+      onClick={handleContainerClick}
+      className="mb-3 p-2 border-bottom hover:bg-gray-100 p-2 rounded d-flex align-items-center"
+    >
+      <div className="flex-grow-1">
+        <p className="mb-1">{notification.mensaje}</p>
+        <small className="text-muted">{timeAgo(notification.created_at)}</small>
+      </div>
+      <div className="d-flex align-items-center">
+        {!notification.leida && (
+          <span className="bg-warning rounded-circle notification-indicator"></span>
+        )}
+        <Button
+          aria-label="Eliminar notificación"
+          variant="outline-danger"
+          size="sm"
+          onClick={() => onDelete(notification.id)}
+          className="ms-2 delete-notification-btn"
+        >
+          <FaTimes />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationItem;
+

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -1,0 +1,84 @@
+import { useState, useEffect, useRef, useContext } from 'react';
+import { AuthContext } from '../context/AuthContext';
+import { get_notificaciones_correctivos, get_notificaciones_preventivos } from '../services/notificaciones';
+import { subscribeToNotifications } from '../services/notificationWs';
+
+const useNotifications = () => {
+  const { currentEntity } = useContext(AuthContext);
+  const [notifications, setNotifications] = useState([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const socketRef = useRef(null);
+
+  const fetchNotifications = async () => {
+    try {
+      const uid = currentEntity?.data?.uid;
+      if (!uid) return;
+
+      const [correctivosResp, preventivosResp] = await Promise.all([
+        get_notificaciones_correctivos(uid),
+        get_notificaciones_preventivos(uid)
+      ]);
+
+      const correctivos = Array.isArray(correctivosResp.data) ? correctivosResp.data : [];
+      const preventivos = Array.isArray(preventivosResp.data) ? preventivosResp.data : [];
+
+      const mappedCorrectivos = correctivos.map((notif) => ({
+        ...notif,
+        tipo: 'correctivo'
+      }));
+
+      const mappedPreventivos = preventivos.map((notif) => ({
+        ...notif,
+        tipo: 'preventivo'
+      }));
+
+      const allNotificaciones = [...mappedCorrectivos, ...mappedPreventivos];
+      setUnreadCount(allNotificaciones.filter(n => !n.leida).length);
+
+      allNotificaciones.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+      setNotifications(allNotificaciones);
+    } catch (error) {
+      console.error('Error obteniendo notificaciones:', error);
+    }
+  };
+
+  useEffect(() => {
+    if (currentEntity?.data?.uid) fetchNotifications();
+  }, [currentEntity?.data?.uid]);
+
+  useEffect(() => {
+    const uid = currentEntity?.data?.uid;
+    if (!uid) return;
+
+    const OPEN = typeof WebSocket !== 'undefined' ? WebSocket.OPEN : 1;
+    if (socketRef.current && socketRef.current.readyState === OPEN) return;
+
+    const onMessage = (data) => {
+      setNotifications((prev) => {
+        const updated = [data, ...prev];
+        setUnreadCount(updated.filter((n) => !n.leida).length);
+        return updated;
+      });
+    };
+
+    const socket = subscribeToNotifications(uid, onMessage);
+    socketRef.current = socket;
+
+    return () => {
+      if (socketRef.current?.close) socketRef.current.close();
+      else if (socketRef.current?.disconnect) socketRef.current.disconnect();
+      socketRef.current = null;
+    };
+  }, [currentEntity?.data?.uid]);
+
+  const disconnect = () => {
+    if (socketRef.current?.close) socketRef.current.close();
+    else if (socketRef.current?.disconnect) socketRef.current.disconnect();
+    socketRef.current = null;
+  };
+
+  return { notifications, unreadCount, fetchNotifications, disconnect };
+};
+
+export default useNotifications;
+

--- a/frontend/src/styles/navbar.css
+++ b/frontend/src/styles/navbar.css
@@ -31,7 +31,7 @@
   position: absolute;
   top: -6px;
   right: -6px;
-  background-color: #ffc107; 
+  background-color: #ffc107;
   color: #000;
   border-radius: 50%;
   padding: 2px 6px;
@@ -39,6 +39,12 @@
   font-weight: bold;
   min-width: 18px;
   text-align: center;
+}
+
+.notification-indicator {
+  width: 10px;
+  height: 10px;
+  margin-left: 10px;
 }
 
 .mark-read-btn {


### PR DESCRIPTION
## Summary
- encapsulate notification fetching and websocket management in `useNotifications`
- render notifications via new `NotificationItem` component and style indicator with CSS class
- streamline deletion without event propagation

## Testing
- `npm test` *(fails: 5 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6cd9dff0832890dd1da8c5d51b7e