### PR TITLE
refactor: centralize config object

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,7 +18,7 @@ import Mapa from './pages/Mapa';
 import Ruta from './pages/Ruta';
 import Reportes from './pages/Reportes';
 import BackButton from './components/BackButton';
-import { mapsApiKey } from './config';
+import { config } from './config';
 import { LoadScript } from '@react-google-maps/api';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'leaflet/dist/leaflet.css';
@@ -74,7 +74,7 @@ const AppContent = () => {
   }, [currentEntity, loading, verifying, isLoginPage, navigate, location]);
 
   return (
-    <LoadScript googleMapsApiKey={mapsApiKey} libraries={googleMapsLibraries}>
+    <LoadScript googleMapsApiKey={config.mapsApiKey} libraries={googleMapsLibraries}>
       <div className="d-flex flex-column min-vh-100">
         {!isLoginPage && <Navbar />}
         <main className="flex-grow-1">

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,5 +1,6 @@
+const isProd = window.location.host.includes('nice-rock');
+
 const getApiUrl = () => {
-  const isProd = window.location.host.includes('nice-rock');
   const apiUrl = import.meta.env[`VITE_API_URL_${isProd ? 'PROD' : 'QA'}`];
 
   if (!apiUrl) {
@@ -11,7 +12,6 @@ const getApiUrl = () => {
 };
 
 const getFirebaseConfig = () => {
-  const isProd = window.location.host.includes('nice-rock');
   const config = import.meta.env[`VITE_FIREBASE_CONFIG_${isProd ? 'PROD' : 'QA'}`];
 
   if (!config) {
@@ -23,7 +23,6 @@ const getFirebaseConfig = () => {
 };
 
 const getMapsApiKey = () => {
-  const isProd = window.location.host.includes('nice-rock');
   const config = import.meta.env[`VITE_GOOGLE_MAPS_API_KEY_${isProd ? 'PROD' : 'QA'}`];
 
   if (!config) {
@@ -35,7 +34,6 @@ const getMapsApiKey = () => {
 };
 
 const getWebPushPublicKey = () => {
-  const isProd = window.location.host.includes('nice-rock');
   const key = import.meta.env[`VITE_WEB_PUSH_PUBLIC_KEY_${isProd ? 'PROD' : 'QA'}`];
 
   if (!key) {
@@ -47,7 +45,6 @@ const getWebPushPublicKey = () => {
 };
 
 const getGoogleClient = () => {
-  const isProd = window.location.host.includes('nice-rock');
   const clientId = import.meta.env[`VITE_GOOGLE_CLIENT_ID_${isProd ? 'PROD' : 'QA'}`];
 
   if (!clientId) {
@@ -58,8 +55,10 @@ const getGoogleClient = () => {
   return clientId;
 };
 
-export const API_URL = getApiUrl();
-export const firebaseConfig = getFirebaseConfig();
-export const mapsApiKey = getMapsApiKey();
-export const googleClientId = getGoogleClient();
-export const webPushPublicKey = getWebPushPublicKey();
+export const config = {
+  API_URL: getApiUrl(),
+  firebaseConfig: getFirebaseConfig(),
+  mapsApiKey: getMapsApiKey(),
+  googleClientId: getGoogleClient(),
+  webPushPublicKey: getWebPushPublicKey(),
+};

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -3,7 +3,7 @@ import { auth, signOut, getPushSubscription, signInWithCredential, GoogleAuthPro
 import { saveSubscription, deleteSubscription } from '../services/notificaciones';
 import api from '../services/api';
 import { useNavigate } from 'react-router-dom';
-import { googleClientId } from '../config';
+import { config } from '../config';
 
 const AuthContext = createContext();
 
@@ -142,7 +142,7 @@ const AuthProvider = ({ children }) => {
       script.onload = () => {
         try {
           window.google.accounts.id.initialize({
-            client_id: googleClientId,
+            client_id: config.googleClientId,
             callback: async (response) => {
               try {
                 const idToken = response.credential;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import { API_URL } from '../config'; 
+import { config } from '../config';
  
 const api = axios.create({
-  baseURL: API_URL,
+  baseURL: config.API_URL,
 });
 
 api.interceptors.request.use(

--- a/frontend/src/services/chatWs.js
+++ b/frontend/src/services/chatWs.js
@@ -1,12 +1,12 @@
-import { API_URL } from '../config';
+import { config } from '../config';
 
 const getWsUrl = (id) => {
-  if (!API_URL) {
+  if (!config.API_URL) {
     console.error('Missing API URL configuration for WebSocket');
     return null;
   }
-  const protocol = API_URL.startsWith('https') ? 'wss' : 'ws';
-  const base = API_URL.replace(/^https?/, protocol);
+  const protocol = config.API_URL.startsWith('https') ? 'wss' : 'ws';
+  const base = config.API_URL.replace(/^https?/, protocol);
   return `${base}/ws/chat/${id}`;
 };
 
@@ -25,3 +25,4 @@ export const subscribeToChat = (id, onMessage) => {
   };
   return socket;
 };
+

--- a/frontend/src/services/firebase.js
+++ b/frontend/src/services/firebase.js
@@ -1,9 +1,9 @@
 import { initializeApp } from 'firebase/app';
 import { getDatabase } from 'firebase/database';
 import { initializeAuth, indexedDBLocalPersistence, browserPopupRedirectResolver, signOut, GoogleAuthProvider, signInWithCredential } from 'firebase/auth';
-import { firebaseConfig, webPushPublicKey } from '../config';
+import { config } from '../config';
 
-const app = initializeApp(firebaseConfig);
+const app = initializeApp(config.firebaseConfig);
 const database = getDatabase(app);
 const auth = initializeAuth(app, {
   persistence: indexedDBLocalPersistence,
@@ -23,7 +23,7 @@ const getPushSubscription = async () => {
     const registration = await navigator.serviceWorker.ready;
     const subscription = await registration.pushManager.subscribe({
       userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(webPushPublicKey)
+      applicationServerKey: urlBase64ToUint8Array(config.webPushPublicKey)
     });
     return subscription;
   } catch (err) {
@@ -33,3 +33,4 @@ const getPushSubscription = async () => {
 };
 
 export { database, auth, getPushSubscription, signOut, GoogleAuthProvider, signInWithCredential };
+

--- a/frontend/src/services/notificationWs.js
+++ b/frontend/src/services/notificationWs.js
@@ -1,12 +1,12 @@
-import { API_URL } from '../config';
+import { config } from '../config';
 
 const getWsUrl = (uid) => {
-  if (!API_URL) {
+  if (!config.API_URL) {
     console.error('Missing API URL configuration for WebSocket');
     return null;
   }
-  const protocol = API_URL.startsWith('https') ? 'wss' : 'ws';
-  const base = API_URL.replace(/^https?/, protocol);
+  const protocol = config.API_URL.startsWith('https') ? 'wss' : 'ws';
+  const base = config.API_URL.replace(/^https?/, protocol);
   return `${base}/ws/notificaciones/${uid}`;
 };
 
@@ -25,3 +25,4 @@ export const subscribeToNotifications = (uid, onMessage) => {
   };
   return socket;
 };
+


### PR DESCRIPTION
## Summary
- consolidate environment detection into a single `isProd` flag
- expose aggregated `config` object for API, Firebase, Maps and Google settings
- refactor services and components to consume new `config` object

## Testing
- `npm test -- --run` *(fails: Test Files 5 failed | 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6cf6a9c48328800845b1f4a6aa4e