### PR TITLE
Refactor auth flow into reusable hooks

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,223 +1,79 @@
-import React, { createContext, useState, useEffect, useRef } from 'react';
-import { auth, signOut, getPushSubscription, signInWithCredential, GoogleAuthProvider } from '../services/firebase';
-import { saveSubscription, deleteSubscription } from '../services/notificaciones';
-import api from '../services/api';
-import { useNavigate } from 'react-router-dom';
+import React, { createContext, useEffect } from 'react';
 import { googleClientId } from '../config';
+import { loadGoogleSDK } from '../utils/googleSignIn';
+import useAuth, { buildUserAuthError } from '../hooks/useAuth';
 
 const AuthContext = createContext();
 
-//Utilidades de errores
-const FRIENDLY_ERRORS = {
-  401: 'No se pudo validar tu sesión. Volvé a iniciar sesión.',
-  403: 'Usuario no registrado. Por favor, crea una cuenta.',
-};
-
-function buildUserAuthError(error, fallback = 'Ocurrió un problema. Intentá de nuevo.') {
-  const status = error?.response?.status;
-  const detail = error?.response?.data?.detail || error?.message;
-
-  // Log técnico detallado (no se muestra al usuario)
-  console.error('Auth error:', {
-    status,
-    detail,
-    stack: error?.stack,
-    url: error?.config?.url,
-    method: error?.config?.method,
-  });
-
-  return FRIENDLY_ERRORS[status] || fallback;
-}
-
 const AuthProvider = ({ children }) => {
-  const [currentUser, setCurrentUser] = useState(null);
-  const [subscription, setSubscription] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [verifying, setVerifying] = useState(false);
-  const [singingIn, setSingingIn] = useState(false); 
-  const navigate = useNavigate();
-  const isVerifyingRef = useRef(false);
-  const isVerifiedRef = useRef(false);
-  const [currentEntity, setCurrentEntity] = useState(() => {
-    try {
-      const stored =
-        sessionStorage.getItem('currentEntity') ||
-        localStorage.getItem('currentEntity');
-      return stored ? JSON.parse(stored) : null;
-    } catch (e) {
-      console.error("Error parsing currentEntity from storage:", e);
-      return null;
-    }
-  });
-
-  const verifyUser = async (user, idToken) => {
-    isVerifyingRef.current = true;
-    for (let i = 0; i < 3; i++) {
-      try {
-        setLoading(true);
-        setVerifying(true);
-
-        const response = await api.post(
-          '/auth/verify',
-          {},
-          { headers: { Authorization: `Bearer ${idToken}` } }
-        );
-
-        // pequeña espera para UX
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        isVerifiedRef.current = true;
-        setCurrentUser(user);
-        setCurrentEntity(response.data);
-        localStorage.setItem('authToken', idToken);
-        sessionStorage.setItem('authToken', idToken);
-        localStorage.setItem('currentEntity', JSON.stringify(response.data));
-        sessionStorage.setItem('currentEntity', JSON.stringify(response.data));
-
-        const push_subscription = await getPushSubscription();
-        if (push_subscription) {
-          const jsonSub = push_subscription.toJSON();
-          setSubscription(jsonSub);
-          await saveSubscription({
-            ...jsonSub,
-            firebase_uid: response?.data?.data?.uid,
-            device_info: navigator.userAgent,
-          });
-        }
-
-        return { success: true, data: response.data };
-      } catch (error) {
-        if (i == 2) {
-          const userMessage = buildUserAuthError(error, 'Error al verificar el usuario.');
-          await logOut(userMessage); 
-          return { success: false, data: null };
-        }
-      } finally {
-        isVerifyingRef.current = false;
-        setLoading(false);
-        setVerifying(false);
-      }
-    }
-  };
-
-  const logOut = async (error) => {
-    try {
-      localStorage.removeItem('authToken');
-      sessionStorage.removeItem('authToken');
-      localStorage.removeItem('googleIdToken');
-      sessionStorage.removeItem('googleIdToken');
-      setLoading(false);
-      setVerifying(false);
-      isVerifyingRef.current = false;
-      isVerifiedRef.current = false;
-      setCurrentUser(null);
-      setCurrentEntity(null);
-
-      if (subscription?.endpoint) {
-        try {
-          await deleteSubscription({ params: { endpoint: subscription.endpoint } });
-        } catch (e) {
-          console.warn('No se pudo eliminar la suscripción de push:', e);
-        }
-      }
-      setSubscription(null);
-
-      await signOut(auth);
-    } catch (e) {
-      console.error('Error al cerrar sesión:', e);
-    } finally {
-      if (error) {
-        navigate('/login', { state: { error } });
-      } else {
-        navigate('/login');
-      }
-    }
-  };
-
+  const {
+    currentUser,
+    currentEntity,
+    loading,
+    verifying,
+    singingIn,
+    verifyUser,
+    logOut,
+    retrySignIn,
+    startSigningIn,
+    stopSigningIn,
+  } = useAuth();
   const signInWithGoogle = async (loginIn) => {
+    await loadGoogleSDK();
     return new Promise((resolve, reject) => {
-      // Cargar SDK de Google
-      const script = document.createElement('script');
-      script.src = 'https://accounts.google.com/gsi/client';
-      script.async = true;
-      script.onload = () => {
-        try {
-          window.google.accounts.id.initialize({
-            client_id: googleClientId,
-            callback: async (response) => {
-              try {
-                const idToken = response.credential;
-                if (loginIn) {
-                  localStorage.setItem('googleIdToken', idToken);
-                  sessionStorage.setItem('googleIdToken', idToken);
-                  setSingingIn(true);
-                } else {
-                  const emailResponse = await fetch(
-                    `https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=${idToken}`
-                  );
-                  const tokenInfo = await emailResponse.json();
-                  if (tokenInfo.email) {
-                    resolve({ idToken, email: tokenInfo.email });
-                  } else {
-                    throw new Error('Failed to retrieve email from Google ID token');
-                  }
-                }
-              } catch (error) {
-                console.error('Error processing Google ID token:', error);
-                reject(error);
-              }
-            },
-            ux_mode: 'popup',
-          });
-          window.google.accounts.id.prompt();
-        } catch (e) {
-          reject(new Error('No se pudo inicializar Google Sign-In.'));
-        }
-      };
-      script.onerror = () => reject(new Error('Failed to load Google Sign-In SDK'));
-      document.body.appendChild(script);
-    });
-  };
-
-  const retrySignIn = async (retries = 3, delay = 1000) => {
-    for (let i = 0; i < retries; i++) {
       try {
-        const idToken = sessionStorage.getItem('googleIdToken') || localStorage.getItem('googleIdToken');
-        if (!idToken) {
-          return; // no hay token; no se hace nada
-        }
-        const credential = GoogleAuthProvider.credential(idToken);
-        const result = await signInWithCredential(auth, credential);
-        return result;
-      } catch (error) {
-        if (error.code === 'auth/network-request-failed' && i < retries - 1) {
-          await new Promise((resolve) => setTimeout(resolve, delay));
-          continue;
-        }
-        throw error;
+        window.google.accounts.id.initialize({
+          client_id: googleClientId,
+          callback: async (response) => {
+            try {
+              const idToken = response.credential;
+              if (loginIn) {
+                localStorage.setItem('googleIdToken', idToken);
+                sessionStorage.setItem('googleIdToken', idToken);
+                startSigningIn();
+              } else {
+                const emailResponse = await fetch(
+                  `https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=${idToken}`
+                );
+                const tokenInfo = await emailResponse.json();
+                if (tokenInfo.email) {
+                  resolve({ idToken, email: tokenInfo.email });
+                } else {
+                  throw new Error('Failed to retrieve email from Google ID token');
+                }
+              }
+            } catch (error) {
+              console.error('Error processing Google ID token:', error);
+              reject(error);
+            }
+          },
+          ux_mode: 'popup',
+        });
+        window.google.accounts.id.prompt();
+      } catch (e) {
+        reject(new Error('No se pudo inicializar Google Sign-In.'));
       }
-    }
+    });
   };
 
   const handleGoogleSignIn = async (isOnload) => {
     try {
       const result = await retrySignIn();
-      const user = result.user;
+      const user = result?.user;
       if (user) {
         const firebaseToken = await user.getIdToken();
         await verifyUser(user, firebaseToken);
       } else {
         if (isOnload) {
           await logOut();
-        }
-        else {
+        } else {
           await logOut('No se pudo obtener el usuario.');
         }
       }
     } catch (error) {
       if (isOnload) {
         await logOut();
-      }
-      else {
+      } else {
         const userMessage = buildUserAuthError(error, 'No se pudo completar el inicio de sesión.');
         await logOut(userMessage);
       }
@@ -226,7 +82,6 @@ const AuthProvider = ({ children }) => {
 
   // Ejecutar al cargar la página
   useEffect(() => {
-    console.log(currentEntity);
     if (!currentEntity) {
       handleGoogleSignIn();
     }
@@ -235,7 +90,7 @@ const AuthProvider = ({ children }) => {
   // Ejecutar cuando se establece un nuevo token
   useEffect(() => {
     if (singingIn) {
-      setSingingIn(false); // evitar loops
+      stopSigningIn();
       handleGoogleSignIn(false);
     }
   }, [singingIn]);

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,163 @@
+import { useState, useReducer, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../services/api';
+import { auth, signOut, GoogleAuthProvider, signInWithCredential } from '../services/firebase';
+import usePushSubscription from './usePushSubscription';
+
+const FRIENDLY_ERRORS = {
+  401: 'No se pudo validar tu sesión. Volvé a iniciar sesión.',
+  403: 'Usuario no registrado. Por favor, crea una cuenta.',
+};
+
+export function buildUserAuthError(error, fallback = 'Ocurrió un problema. Intentá de nuevo.') {
+  const status = error?.response?.status;
+  const detail = error?.response?.data?.detail || error?.message;
+
+  console.error('Auth error:', {
+    status,
+    detail,
+    stack: error?.stack,
+    url: error?.config?.url,
+    method: error?.config?.method,
+  });
+
+  return FRIENDLY_ERRORS[status] || fallback;
+}
+
+const initialState = { loading: false, verifying: false, singingIn: false };
+function reducer(state, action) {
+  switch (action.type) {
+    case 'SET_LOADING':
+      return { ...state, loading: action.value };
+    case 'SET_VERIFYING':
+      return { ...state, verifying: action.value };
+    case 'SET_SIGNING_IN':
+      return { ...state, singingIn: action.value };
+    default:
+      return state;
+  }
+}
+
+export default function useAuth() {
+  const [currentUser, setCurrentUser] = useState(null);
+  const [currentEntity, setCurrentEntity] = useState(() => {
+    try {
+      const stored =
+        sessionStorage.getItem('currentEntity') ||
+        localStorage.getItem('currentEntity');
+      return stored ? JSON.parse(stored) : null;
+    } catch (e) {
+      console.error('Error parsing currentEntity from storage:', e);
+      return null;
+    }
+  });
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const navigate = useNavigate();
+  const isVerifyingRef = useRef(false);
+  const isVerifiedRef = useRef(false);
+  const { subscription, subscribe, unsubscribe } = usePushSubscription();
+
+  const verifyUser = async (user, idToken) => {
+    isVerifyingRef.current = true;
+    for (let i = 0; i < 3; i++) {
+      try {
+        dispatch({ type: 'SET_LOADING', value: true });
+        dispatch({ type: 'SET_VERIFYING', value: true });
+
+        const response = await api.post(
+          '/auth/verify',
+          {},
+          { headers: { Authorization: `Bearer ${idToken}` } }
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        isVerifiedRef.current = true;
+        setCurrentUser(user);
+        setCurrentEntity(response.data);
+        localStorage.setItem('authToken', idToken);
+        sessionStorage.setItem('authToken', idToken);
+        localStorage.setItem('currentEntity', JSON.stringify(response.data));
+        sessionStorage.setItem('currentEntity', JSON.stringify(response.data));
+
+        await subscribe(response?.data?.data?.uid);
+
+        return { success: true, data: response.data };
+      } catch (error) {
+        if (i === 2) {
+          const userMessage = buildUserAuthError(error, 'Error al verificar el usuario.');
+          await logOut(userMessage);
+          return { success: false, data: null };
+        }
+      } finally {
+        isVerifyingRef.current = false;
+        dispatch({ type: 'SET_LOADING', value: false });
+        dispatch({ type: 'SET_VERIFYING', value: false });
+      }
+    }
+  };
+
+  const logOut = async (error) => {
+    try {
+      localStorage.removeItem('authToken');
+      sessionStorage.removeItem('authToken');
+      localStorage.removeItem('googleIdToken');
+      sessionStorage.removeItem('googleIdToken');
+      dispatch({ type: 'SET_LOADING', value: false });
+      dispatch({ type: 'SET_VERIFYING', value: false });
+      isVerifyingRef.current = false;
+      isVerifiedRef.current = false;
+      setCurrentUser(null);
+      setCurrentEntity(null);
+
+      await unsubscribe();
+      await signOut(auth);
+    } catch (e) {
+      console.error('Error al cerrar sesión:', e);
+    } finally {
+      if (error) {
+        navigate('/login', { state: { error } });
+      } else {
+        navigate('/login');
+      }
+    }
+  };
+
+  const retrySignIn = async (retries = 3, delay = 1000) => {
+    for (let i = 0; i < retries; i++) {
+      try {
+        const idToken =
+          sessionStorage.getItem('googleIdToken') ||
+          localStorage.getItem('googleIdToken');
+        if (!idToken) {
+          return;
+        }
+        const credential = GoogleAuthProvider.credential(idToken);
+        const result = await signInWithCredential(auth, credential);
+        return result;
+      } catch (error) {
+        if (error.code === 'auth/network-request-failed' && i < retries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+        throw error;
+      }
+    }
+  };
+
+  const startSigningIn = () => dispatch({ type: 'SET_SIGNING_IN', value: true });
+  const stopSigningIn = () => dispatch({ type: 'SET_SIGNING_IN', value: false });
+
+  return {
+    currentUser,
+    currentEntity,
+    loading: state.loading,
+    verifying: state.verifying,
+    singingIn: state.singingIn,
+    verifyUser,
+    logOut,
+    retrySignIn,
+    startSigningIn,
+    stopSigningIn,
+    subscription,
+  };
+}

--- a/frontend/src/hooks/usePushSubscription.js
+++ b/frontend/src/hooks/usePushSubscription.js
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { getPushSubscription } from '../services/firebase';
+import { saveSubscription, deleteSubscription } from '../services/notificaciones';
+
+export default function usePushSubscription() {
+  const [subscription, setSubscription] = useState(null);
+
+  const subscribe = async (firebaseUid) => {
+    const pushSubscription = await getPushSubscription();
+    if (pushSubscription) {
+      const jsonSub = pushSubscription.toJSON();
+      setSubscription(jsonSub);
+      await saveSubscription({
+        ...jsonSub,
+        firebase_uid: firebaseUid,
+        device_info: navigator.userAgent,
+      });
+    }
+  };
+
+  const unsubscribe = async () => {
+    if (subscription?.endpoint) {
+      try {
+        await deleteSubscription({ params: { endpoint: subscription.endpoint } });
+      } catch (e) {
+        console.warn('No se pudo eliminar la suscripción de push:', e);
+      }
+    }
+    setSubscription(null);
+  };
+
+  return { subscription, subscribe, unsubscribe };
+}

--- a/frontend/src/utils/googleSignIn.js
+++ b/frontend/src/utils/googleSignIn.js
@@ -1,0 +1,15 @@
+let sdkPromise;
+
+export function loadGoogleSDK() {
+  if (!sdkPromise) {
+    sdkPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = 'https://accounts.google.com/gsi/client';
+      script.async = true;
+      script.onload = resolve;
+      script.onerror = () => reject(new Error('Failed to load Google Sign-In SDK'));
+      document.body.appendChild(script);
+    });
+  }
+  return sdkPromise;
+}


### PR DESCRIPTION
## Summary
- Extract push notification subscription into `usePushSubscription` hook
- Add `useAuth` hook managing auth flow with `useReducer`
- Externalize Google SDK loading to `utils/googleSignIn`
- Update `AuthContext` to use new hooks and reducer state

## Testing
- `npm test` *(fails: 5 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6d0457608328b59ff67dd750fe45