### PR TITLE
refactor: extract mantenimiento info component

### DIFF
--- a/frontend/src/components/MantenimientoInfo.jsx
+++ b/frontend/src/components/MantenimientoInfo.jsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { Col, Form, Button, Alert } from 'react-bootstrap';
+import { FiPlusCircle, FiCheckCircle } from 'react-icons/fi';
+import { BsSave } from 'react-icons/bs';
+
+const MantenimientoInfo = ({
+  title,
+  mantenimiento,
+  currentEntity,
+  formData,
+  getSucursalNombre,
+  getCuadrillaNombre,
+  getZonaNombre,
+  formatExtendido,
+  handleExtendidoChange,
+  handleSubmit,
+  error,
+  success,
+  toggleRoute,
+  isSelected,
+  showFinishButton,
+  handleFinish,
+  handleChange,
+}) => (
+  <Col className="info-section">
+    <h4 className="info-section-title">{title}</h4>
+    <div className="info-field">
+      <strong className="info-label">
+        {mantenimiento.frecuencia ? 'Sucursal - Frecuencia:' : 'Sucursal:'}
+      </strong>{' '}
+      {mantenimiento.id_sucursal ? getSucursalNombre(mantenimiento.id_sucursal) : 'N/A'}
+      {mantenimiento.frecuencia && ` - ${mantenimiento.frecuencia}`}
+    </div>
+    <div className="info-field">
+      <strong className="info-label">Cuadrilla:</strong>{' '}
+      {mantenimiento.id_cuadrilla ? getCuadrillaNombre(mantenimiento.id_cuadrilla) : 'N/A'}
+    </div>
+    <div className="info-field">
+      <strong className="info-label">Zona:</strong>{' '}
+      {mantenimiento.id_sucursal ? getZonaNombre(mantenimiento.id_sucursal) : 'N/A'}
+    </div>
+    <div className="info-field">
+      <strong className="info-label">Fecha Apertura:</strong>{' '}
+      {mantenimiento.fecha_apertura?.split('T')[0] || 'N/A'}
+    </div>
+    {mantenimiento.numero_caso && (
+      <div className="info-field">
+        <strong className="info-label">Numero de Caso:</strong>{' '}
+        {mantenimiento.numero_caso}
+      </div>
+    )}
+    {mantenimiento.incidente && (
+      <div className="info-field">
+        <strong className="info-label">Incidente:</strong>{' '}
+        {mantenimiento.incidente}
+      </div>
+    )}
+    {mantenimiento.rubro && (
+      <div className="info-field">
+        <strong className="info-label">Rubro:</strong>{' '}
+        {mantenimiento.rubro}
+      </div>
+    )}
+    {mantenimiento.prioridad && (
+      <div className="info-field">
+        <strong className="info-label">Prioridad:</strong>{' '}
+        {mantenimiento.prioridad}
+      </div>
+    )}
+    {mantenimiento.estado && (
+      <div className="info-field">
+        <strong className="info-label">Estado:</strong>{' '}
+        {mantenimiento.estado}
+      </div>
+    )}
+    <div className="info-field">
+      <strong className="info-label">Fecha Cierre:</strong>{' '}
+      {mantenimiento.fecha_cierre?.split('T')[0] || 'Mantenimiento no finalizado'}
+    </div>
+    <div className="info-field">
+      <strong className="info-label">Extendido:</strong>{' '}
+      {mantenimiento.extendido
+        ? `${formatExtendido(mantenimiento.extendido)} hs`
+        : 'No hay extendido'}
+    </div>
+    {currentEntity?.type !== 'usuario' && (
+      <Form className="info-form" onSubmit={handleSubmit}>
+        <Form.Group className="extendido-row">
+          <Form.Label className="extendido-label">Extendido:</Form.Label>
+          <Form.Control
+            type="datetime-local"
+            name="extendido"
+            value={formData?.extendido}
+            onChange={handleExtendidoChange}
+            placeholder="Seleccionar fecha"
+            className="extendido-input"
+          />
+        </Form.Group>
+        {error && <Alert variant="danger">{error}</Alert>}
+        {success && <Alert variant="success">{success}</Alert>}
+      </Form>
+    )}
+    {currentEntity?.type !== 'usuario' && (
+      <Button
+        variant={isSelected ? 'danger' : 'success'}
+        className="info-button-add"
+        onClick={toggleRoute}
+      >
+        <FiPlusCircle className="me-2" size={18} />
+        {isSelected ? 'Borrar de la ruta' : 'Agregar a la ruta actual'}
+      </Button>
+    )}
+    {showFinishButton && (
+      <Button variant="dark" className="info-button-finish" onClick={handleFinish}>
+        <FiCheckCircle className="me-2" size={18} />Marcar como finalizado
+      </Button>
+    )}
+    {currentEntity?.type === 'usuario' && handleChange && (
+      <Form className="info-form" onSubmit={handleSubmit}>
+        <Form.Group className="extendido-row" controlId="estado">
+          <Form.Label className="extendido-label">Estado</Form.Label>
+          <Form.Select
+            name="estado"
+            value={formData?.estado || ''}
+            onChange={handleChange}
+            className="form-select"
+          >
+            <option value="Pendiente">Pendiente</option>
+            <option value="En Progreso">En Progreso</option>
+            <option value="Finalizado">Finalizado</option>
+            <option value="A Presupuestar">A Presupuestar</option>
+            <option value="Presupuestado">Presupuestado</option>
+            <option value="Presupuesto Aprobado">Presupuesto Aprobado</option>
+            <option value="Esperando Respuesta Bancor">Esperando Respuesta Bancor</option>
+            <option value="Aplazado">Aplazado</option>
+            <option value="Desestimado">Desestimado</option>
+            <option value="Solucionado">Solucionado</option>
+          </Form.Select>
+        </Form.Group>
+        {error && <Alert variant="danger">{error}</Alert>}
+        {success && <Alert variant="success">{success}</Alert>}
+      </Form>
+    )}
+    <button
+      className="floating-save-btn d-flex align-items-center justify-content-center"
+      onClick={handleSubmit}
+      title="Guardar cambios"
+    >
+      <BsSave size={28} />
+    </button>
+  </Col>
+);
+
+export default MantenimientoInfo;
+

--- a/frontend/src/pages/Correctivo.jsx
+++ b/frontend/src/pages/Correctivo.jsx
@@ -8,12 +8,12 @@ import { getSucursales } from '../services/sucursalService';
 import { getCuadrillas } from '../services/cuadrillaService';
 import { selectCorrectivo, deleteCorrectivo } from '../services/maps';
 import 'bootstrap-icons/font/bootstrap-icons.css';
-import { FiSend, FiPlusCircle, FiCheckCircle, FiArrowLeft, FiMessageSquare } from "react-icons/fi";
-import { BsSave } from 'react-icons/bs';
+import { FiSend, FiArrowLeft, FiMessageSquare } from "react-icons/fi";
 import { getChatCorrectivo, sendMessageCorrectivo } from '../services/chats';
 import { subscribeToChat } from '../services/chatWs';
 import BackButton from '../components/BackButton';
 import LoadingSpinner from '../components/LoadingSpinner';
+import MantenimientoInfo from '../components/MantenimientoInfo';
 import '../styles/mantenimientos.css';
 
 const Correctivo = () => {
@@ -460,114 +460,25 @@ const Correctivo = () => {
       ) : (
         <div className="page-content">
           <Row className="main-row">
-            <Col className="info-section">
-              <h4 className="info-section-title">Mantenimiento Correctivo</h4>
-              <div className="info-field">
-                <strong className="info-label">Sucursal:</strong>{' '}
-                {mantenimiento.id_sucursal ? getSucursalNombre(mantenimiento.id_sucursal) : 'N/A'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Cuadrilla:</strong>{' '}
-                {mantenimiento.id_cuadrilla ? getCuadrillaNombre(mantenimiento.id_cuadrilla) : 'N/A'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Zona:</strong>{' '}
-                {mantenimiento.id_sucursal ? getZonaNombre(mantenimiento.id_sucursal) : 'N/A'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Fecha Apertura:</strong>{' '}
-                {mantenimiento.fecha_apertura?.split('T')[0] || 'N/A'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Numero de Caso:</strong>{' '}
-                {mantenimiento.numero_caso}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Incidente:</strong>{' '}
-                {mantenimiento.incidente}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Rubro:</strong>{' '}
-                {mantenimiento.rubro}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Prioridad:</strong>{' '}
-                {mantenimiento.prioridad}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Estado:</strong>{' '}
-                {mantenimiento.estado}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Fecha Cierre:</strong>{' '}
-                {mantenimiento.fecha_cierre?.split('T')[0] || 'Mantenimiento no finalizado'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Extendido:</strong>{' '}
-                {mantenimiento.extendido
-                  ? `${formatExtendido(mantenimiento.extendido)} hs`
-                  : 'No hay extendido'}
-              </div>
-              {currentEntity.type !== 'usuario' && (
-                <Form className="info-form" onSubmit={handleSubmit}>
-                  <Form.Group className="extendido-row">
-                    <Form.Label className="extendido-label">Extendido:</Form.Label>
-                    <Form.Control 
-                      type="datetime-local" 
-                      name="extendido"
-                      value={formData.extendido}
-                      onChange={handleExtendidoChange}
-                      placeholder="Seleccionar fecha" 
-                      className="extendido-input" />
-                  </Form.Group>
-                  {error && <Alert variant="danger">{error}</Alert>}
-                  {success && <Alert variant="success">{success}</Alert>}
-                </Form>
-              )}
-              {currentEntity.type !== 'usuario' && (
-                <Button variant={isSelected ? 'danger' : 'success'} className="info-button-add" onClick={toggleRoute}>
-                  <FiPlusCircle className="me-2" size={18} />{isSelected ? 'Borrar de la ruta' : 'Agregar a la ruta actual'}
-                </Button>
-              )}
-              {currentEntity.type !== 'usuario' && mantenimiento.estado !== 'Finalizado' && mantenimiento.estado !== 'Solucionado' && (
-                <Button variant="dark" className="info-button-finish" onClick={handleFinish}>
-                  <FiCheckCircle className="me-2" size={18} />Marcar como finalizado
-                </Button>
-              )}
-              {currentEntity.type === 'usuario' && (
-                <Form className="info-form" onSubmit={handleSubmit}>
-                  <Form.Group className="extendido-row" controlId="estado">
-                    <Form.Label className="extendido-label">Estado</Form.Label>
-                    <Form.Select
-                      name="estado"
-                      value={formData.estado || ''}
-                      onChange={handleChange}
-                      className='form-select'
-                    >
-                      <option value="Pendiente">Pendiente</option>
-                      <option value="En Progreso">En Progreso</option>
-                      <option value="Finalizado">Finalizado</option>
-                      <option value="A Presupuestar">A Presupuestar</option>
-                      <option value="Presupuestado">Presupuestado</option>
-                      <option value="Presupuesto Aprobado">Presupuesto Aprobado</option>
-                      <option value="Esperando Respuesta Bancor">Esperando Respuesta Bancor</option>
-                      <option value="Aplazado">Aplazado</option>
-                      <option value="Desestimado">Desestimado</option>
-                      <option value="Solucionado">Solucionado</option>
-                    </Form.Select>
-                  </Form.Group>
-                  {error && <Alert variant="danger">{error}</Alert>}
-                  {success && <Alert variant="success">{success}</Alert>}
-                </Form>
-              )}
-              <button
-                className="floating-save-btn d-flex align-items-center justify-content-center"
-                onClick={handleSubmit}
-                title="Guardar cambios"
-              >
-                <BsSave size={28} />
-              </button>
-            </Col>
+            <MantenimientoInfo
+              title="Mantenimiento Correctivo"
+              mantenimiento={mantenimiento}
+              currentEntity={currentEntity}
+              formData={formData}
+              getSucursalNombre={getSucursalNombre}
+              getCuadrillaNombre={getCuadrillaNombre}
+              getZonaNombre={getZonaNombre}
+              formatExtendido={formatExtendido}
+              handleExtendidoChange={handleExtendidoChange}
+              handleSubmit={handleSubmit}
+              error={error}
+              success={success}
+              toggleRoute={toggleRoute}
+              isSelected={isSelected}
+              showFinishButton={currentEntity.type !== 'usuario' && mantenimiento.estado !== 'Finalizado' && mantenimiento.estado !== 'Solucionado'}
+              handleFinish={handleFinish}
+              handleChange={handleChange}
+            />
             {!isMobile && (
               <Col className="chat-section">
                 {renderChatContent()}

--- a/frontend/src/pages/Preventivo.jsx
+++ b/frontend/src/pages/Preventivo.jsx
@@ -8,12 +8,12 @@ import { getCuadrillas } from '../services/cuadrillaService';
 import { getSucursales } from '../services/sucursalService';
 import { selectPreventivo, deletePreventivo } from '../services/maps';
 import 'bootstrap-icons/font/bootstrap-icons.css';
-import { FiSend, FiPlusCircle, FiCheckCircle, FiArrowLeft, FiMessageSquare } from "react-icons/fi";
-import { BsSave } from 'react-icons/bs';
+import { FiSend, FiArrowLeft, FiMessageSquare } from "react-icons/fi";
 import { getChatPreventivo, sendMessagePreventivo } from '../services/chats';
 import { subscribeToChat } from '../services/chatWs';
 import BackButton from '../components/BackButton';
 import LoadingSpinner from '../components/LoadingSpinner';
+import MantenimientoInfo from '../components/MantenimientoInfo';
 import '../styles/mantenimientos.css';
 
 const Preventivo = () => {
@@ -435,68 +435,24 @@ const Preventivo = () => {
       ) : (
         <div className="page-content">
           <Row className="main-row">
-            <Col className="info-section">
-              <h4 className="info-section-title">Mantenimiento Preventivo</h4>
-              <div className="info-field">
-                <strong className="info-label">Sucursal - Frecuencia:</strong>{' '}
-                {mantenimiento.id_sucursal ? getSucursalNombre(mantenimiento.id_sucursal) : 'N/A'} - {mantenimiento.frecuencia || 'N/A'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Cuadrilla:</strong>{' '}
-                {mantenimiento.id_cuadrilla ? getCuadrillaNombre(mantenimiento.id_cuadrilla) : 'N/A'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Zona:</strong>{' '}
-                {mantenimiento.id_sucursal ? getZonaNombre(mantenimiento.id_sucursal) : 'N/A'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Fecha Apertura:</strong>{' '}
-                {mantenimiento.fecha_apertura?.split('T')[0] || 'N/A'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Fecha Cierre:</strong>{' '}
-                {mantenimiento.fecha_cierre?.split('T')[0] || 'Mantenimiento no finalizado'}
-              </div>
-              <div className="info-field">
-                <strong className="info-label">Extendido:</strong>{' '}
-                {mantenimiento.extendido
-                  ? `${formatExtendido(mantenimiento.extendido)} hs`
-                  : 'No hay extendido'}
-              </div>
-              {currentEntity.type !== 'usuario' && (
-                <Form className="info-form" onSubmit={handleSubmit}>
-                  <Form.Group className="extendido-row">
-                    <Form.Label className="extendido-label">Extendido:</Form.Label>
-                    <Form.Control 
-                      type="datetime-local" 
-                      name="extendido"
-                      value={formData.extendido}
-                      onChange={handleExtendidoChange}
-                      placeholder="Seleccionar fecha" 
-                      className="extendido-input" />
-                  </Form.Group>
-                  {error && <Alert variant="danger">{error}</Alert>}
-                  {success && <Alert variant="success">{success}</Alert>}
-                </Form>
-              )}
-              {currentEntity.type !== 'usuario' && (
-                <Button variant={isSelected ? 'danger' : 'success'} className="info-button-add" onClick={toggleRoute}>
-                  <FiPlusCircle className="me-2" size={18} />{isSelected ? 'Borrar de la ruta' : 'Agregar a la ruta actual'}
-                </Button>
-              )}
-              {mantenimiento.fecha_cierre === null && (
-                <Button variant="dark" className="info-button-finish" onClick={handleFinish}>
-                  <FiCheckCircle className="me-2" size={18} />Marcar como finalizado
-                </Button>
-              )}
-              <button
-                className="floating-save-btn d-flex align-items-center justify-content-center"
-                onClick={handleSubmit}
-                title="Guardar cambios"
-              >
-                <BsSave size={28} />
-              </button>
-            </Col>
+            <MantenimientoInfo
+              title="Mantenimiento Preventivo"
+              mantenimiento={mantenimiento}
+              currentEntity={currentEntity}
+              formData={formData}
+              getSucursalNombre={getSucursalNombre}
+              getCuadrillaNombre={getCuadrillaNombre}
+              getZonaNombre={getZonaNombre}
+              formatExtendido={formatExtendido}
+              handleExtendidoChange={handleExtendidoChange}
+              handleSubmit={handleSubmit}
+              error={error}
+              success={success}
+              toggleRoute={toggleRoute}
+              isSelected={isSelected}
+              showFinishButton={mantenimiento.fecha_cierre === null}
+              handleFinish={handleFinish}
+            />
             {!isMobile && (
               <Col className="chat-section">
                 {renderChatContent()}


### PR DESCRIPTION
## Summary
- create reusable MantenimientoInfo component
- use MantenimientoInfo in Correctivo and Preventivo pages

## Testing
- `npm test` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7862f06c8328a60d612587645699